### PR TITLE
Fix for line_to_point_distance_jacobian error

### DIFF
--- a/robot_modeling/DQ_Kinematics.m
+++ b/robot_modeling/DQ_Kinematics.m
@@ -285,8 +285,8 @@ classdef DQ_Kinematics < handle
         
             n_columns = size(line_jacobian,2);
 
-            Jl = line_jacobian(1:4, n_columns);
-            Jm = line_jacobian(5:8, n_columns);
+            Jl = line_jacobian(1:4, 1:n_columns);
+            Jm = line_jacobian(5:8, 1:n_columns);
 
             % Extract line direction
             l = P(robot_line);


### PR DESCRIPTION
Hello, @bvadorno!

There was a small mistake in lines 288 and 289 of `robot_modeling/DQ_Kinematics.m` inside `line_to_point_distance_jacobian()` in which only the last column was being used to create Jl and Jm instead of all the columns as expected.

This was causing the resulting Jacobian to be a real number instead of the expected line vector.