### PR TITLE
Remove Position from the enumeration in ControlObjective.m

### DIFF
--- a/robot_control/ControlObjective.m
+++ b/robot_control/ControlObjective.m
@@ -1,5 +1,5 @@
 classdef ControlObjective
     enumeration 
-        Distance, Line, None, Plane, Pose, Position, Rotation, Translation
+        Distance, Line, None, Plane, Pose, Rotation, Translation
     end
 end


### PR DESCRIPTION
This pull request removes the unused Position element from the ControlObjective enumeration.

It was probably the same as Translation?