### PR TITLE
[GithubActions] Adding release branch tests.

### DIFF
--- a/.github/workflows/matlab_test.yml
+++ b/.github/workflows/matlab_test.yml
@@ -19,10 +19,10 @@ jobs:
         git fetch --prune --unshallow
     - name: Clone the matlab-tests repository
       run: |
-        git clone -b ${{ testbranches.os }} https://github.com/dqrobotics/matlab-tests
+        git clone -b ${{ matrix.testbranches }} https://github.com/dqrobotics/matlab-tests
     - name: Clone the matlab-examples repository
       run: |
-        git clone -b ${{ testbranches.os }} https://github.com/dqrobotics/matlab-examples
+        git clone -b ${{ matrix.testbranches }} https://github.com/dqrobotics/matlab-examples
     - name: Set correct execution path
       run: |
         printf "folder=fileparts(which('startup.m'))\n

--- a/.github/workflows/matlab_test.yml
+++ b/.github/workflows/matlab_test.yml
@@ -17,10 +17,10 @@ jobs:
       run: |
         git submodule update --init --recursive
         git fetch --prune --unshallow
-    - name: Clone the matlab-tests repository
+    - name: Clone the matlab-tests repository (${{ matrix.testbranches }})
       run: |
         git clone -b ${{ matrix.testbranches }} https://github.com/dqrobotics/matlab-tests
-    - name: Clone the matlab-examples repository
+    - name: Clone the matlab-examples repository (${{ matrix.testbranches }})
       run: |
         git clone -b ${{ matrix.testbranches }} https://github.com/dqrobotics/matlab-examples
     - name: Set correct execution path

--- a/.github/workflows/matlab_test.yml
+++ b/.github/workflows/matlab_test.yml
@@ -5,11 +5,11 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ['MATLAB']
     strategy:
       fail-fast: false
       matrix:
-        os: ['MATLAB']
+        testbranches: ['release','master']
 
     steps:
     - uses: actions/checkout@v2
@@ -19,10 +19,10 @@ jobs:
         git fetch --prune --unshallow
     - name: Clone the matlab-tests repository
       run: |
-        git clone https://github.com/dqrobotics/matlab-tests
+        git clone -b ${{ testbranches.os }} https://github.com/dqrobotics/matlab-tests
     - name: Clone the matlab-examples repository
       run: |
-        git clone https://github.com/dqrobotics/matlab-examples
+        git clone -b ${{ testbranches.os }} https://github.com/dqrobotics/matlab-examples
     - name: Set correct execution path
       run: |
         printf "folder=fileparts(which('startup.m'))\n


### PR DESCRIPTION
Guaranteeing that the test pipeline tests both the `release` and `master` branches of `matlab-tests` and `matlab-examples`.