### PR TITLE
This commit fixes the bug #76

### DIFF
--- a/robot_modeling/DQ_SerialManipulator.m
+++ b/robot_modeling/DQ_SerialManipulator.m
@@ -158,12 +158,12 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
         end
 
         function ret = get_joint_types(obj)
-            % GET_JOINT_TYPES() returns the vector of the joint types.
+            % GET_JOINT_TYPES() returns a vector containing the joint types.
             ret = obj.joint_types;
         end
 
-        function ret = get_joint_type(obj, ith_joint)
-            % GET_JOINT_TYPE(ith_joint) returns a vector containing the joint types.
+        function ret = get_joint_type(obj, ith_joint) 
+            % GET_JOINT_TYPE(ith_joint) returns the joint type of the ith joint.
             ret = obj.joint_types(ith_joint);
         end
         

--- a/robot_modeling/DQ_SerialManipulator.m
+++ b/robot_modeling/DQ_SerialManipulator.m
@@ -51,6 +51,7 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
         % mainly in the plot function.
         handle
         n_links;
+        joint_types;
     end
 
      methods (Abstract, Access = protected)   
@@ -74,7 +75,46 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
         % Usage: w = get_w(ith), where
         %          ith: link number
         w = get_w(obj,ith) ; 
+
+        % This method returns the supported joint types.
+        st = get_supported_joint_types(~);
      end
+
+     methods (Access = protected)  
+         function check_joint_types(obj)
+            %  CHECK_JOINT_TYPES() throws an exception if the joint types
+            %  are different from the supported joints.
+            types = obj.get_joint_types();
+            supported_types = obj.get_supported_joint_types();
+            n = size(types, 2);
+            k = size(supported_types, 2);
+            %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+            %  Create a string containing the valid type of joints.
+            msg = 'Unsupported joint types. Use valid joint types: '; 
+            for i=1:k
+              msg_type = ' DQ_JointType.' + string(supported_types(i));  
+              if i==k
+                  ps = '. ';
+              else
+                  ps = ', ';
+              end
+              msg = msg + msg_type + ps;
+            end
+            %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+            for i=1:n
+                  match = false;
+                  for j=1:k
+                      if types(i) == supported_types(j)
+                          match = true;
+                          break;
+                      end
+                  end
+                  if match == false
+                      error(msg);
+                  end
+            end
+         end
+     end 
 
     methods
         function obj = DQ_SerialManipulator()
@@ -97,6 +137,32 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
         function set_effector(obj,effector)
             % SET_EFFECTOR(effector) sets the pose of the effector         
             obj.effector = DQ(effector);
+        end
+
+         function set_joint_types(obj, joint_types)
+            %  SET_JOINT_TYPES(joint_types) sets the joint types.
+            % 'joint_types' the vector that contains the joint types.
+            obj.joint_types = joint_types;
+            obj.check_joint_types();
+        end
+
+        function set_joint_type(obj, joint_type, ith_joint)
+            % SET_JOINT_TYPE(joint_type, ith_joint) sets the joint type of the ith
+            % joint.
+            % 'joint_type' type of joint to be set.
+            % 'ith_joint' ith joint to be set.
+            obj.joint_types(ith_joint) = joint_type;
+            obj.check_joint_types();
+        end
+
+        function ret = get_joint_types(obj)
+            % GET_JOINT_TYPES() returns the vector of the joint types.
+            ret = obj.joint_types;
+        end
+
+        function ret = get_joint_type(obj, ith_joint)
+            % GET_JOINT_TYPE(ith_joint) returns the joint type of the ith joint.
+            ret = obj.joint_types(ith_joint);
         end
         
         function x = fkm(obj,q, ith)

--- a/robot_modeling/DQ_SerialManipulator.m
+++ b/robot_modeling/DQ_SerialManipulator.m
@@ -15,7 +15,7 @@
 %
 % See also DQ_Kinematics.
 
-% (C) Copyright 2011-2022 DQ Robotics Developers
+% (C) Copyright 2011-2023 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %

--- a/robot_modeling/DQ_SerialManipulator.m
+++ b/robot_modeling/DQ_SerialManipulator.m
@@ -143,7 +143,7 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
 
          function set_joint_types(obj, joint_types)
             %  SET_JOINT_TYPES(joint_types) sets the joint types.
-            % 'joint_types' the vector that contains the joint types.
+            % 'joint_types' is a vector containing the joint types.
             obj.joint_types = joint_types;
             obj.check_joint_types();
         end
@@ -163,7 +163,7 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
         end
 
         function ret = get_joint_type(obj, ith_joint)
-            % GET_JOINT_TYPE(ith_joint) returns the joint type of the ith joint.
+            % GET_JOINT_TYPE(ith_joint) returns a vector containing the joint types.
             ret = obj.joint_types(ith_joint);
         end
         

--- a/robot_modeling/DQ_SerialManipulator.m
+++ b/robot_modeling/DQ_SerialManipulator.m
@@ -74,10 +74,12 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
         % Human-Robot Collaboration' by Bruno Adorno.
         % Usage: w = get_w(ith), where
         %          ith: link number
-        w = get_w(obj,ith) ; 
+        w = get_w(obj,ith) ;   
+     end
 
-        % This method returns the supported joint types.
-        st = get_supported_joint_types(~);
+     methods (Abstract, Static, Access = protected) 
+         % This method returns the supported joint types.
+        st = get_supported_joint_types();
      end
 
      methods (Access = protected)  

--- a/robot_modeling/DQ_SerialManipulatorDH.m
+++ b/robot_modeling/DQ_SerialManipulatorDH.m
@@ -30,7 +30,7 @@
 %       set_effector - Set an arbitrary end-effector rigid transformation with respect to the last frame in the kinematic chain.
 % See also DQ_SerialManipulator.
 
-% (C) Copyright 2020-2022 DQ Robotics Developers
+% (C) Copyright 2020-2023 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %

--- a/robot_modeling/DQ_SerialManipulatorDH.m
+++ b/robot_modeling/DQ_SerialManipulatorDH.m
@@ -149,12 +149,13 @@ classdef DQ_SerialManipulatorDH < DQ_SerialManipulator
                 w = DQ.E*DQ.k;
             end
         end
+    end
 
-
-        function ret = get_supported_joint_types(~)
-        % This method returns the supported joint types.
+    methods (Static, Access = protected) 
+         function ret = get_supported_joint_types()
+         % This method returns the supported joint types.
             ret = [DQ_JointType.REVOLUTE, DQ_JointType.PRISMATIC];
-        end
+         end
     end
     
     methods

--- a/robot_modeling/DQ_SerialManipulatorDH.m
+++ b/robot_modeling/DQ_SerialManipulatorDH.m
@@ -71,7 +71,6 @@
 classdef DQ_SerialManipulatorDH < DQ_SerialManipulator
     properties
         theta,d,a,alpha;
-        type
     end
     
     properties (Constant)
@@ -106,7 +105,7 @@ classdef DQ_SerialManipulatorDH < DQ_SerialManipulator
             a = obj.a(ith);
             half_alpha = obj.alpha(ith)/2.0;
             % Add the effect of the joint value
-            if obj.type(ith) == DQ_JointType.REVOLUTE
+            if obj.get_joint_type(ith) == DQ_JointType.REVOLUTE
                 % If joint is revolute
                 half_theta = half_theta + (q/2.0);
             else
@@ -141,7 +140,7 @@ classdef DQ_SerialManipulatorDH < DQ_SerialManipulator
         % Human-Robot Collaboration' by Bruno Adorno.
         % Usage: w = get_w(ith), where
         %          ith: link number    
-            if obj.type(ith) == DQ_JointType.REVOLUTE
+            if obj.get_joint_type(ith) == DQ_JointType.REVOLUTE
                 w = DQ.k;
             else
                 % see Table 1 of "Dynamics of Mobile Manipulators using Dual Quaternion Algebra."
@@ -149,6 +148,12 @@ classdef DQ_SerialManipulatorDH < DQ_SerialManipulator
                 % ASME. J. Mechanisms Robotics. doi: https://doi.org/10.1115/1.4054320
                 w = DQ.E*DQ.k;
             end
+        end
+
+
+        function ret = get_supported_joint_types(~)
+        % This method returns the supported joint types.
+            ret = [DQ_JointType.REVOLUTE, DQ_JointType.PRISMATIC];
         end
     end
     
@@ -189,7 +194,7 @@ classdef DQ_SerialManipulatorDH < DQ_SerialManipulator
             obj.d     = A(2,:);
             obj.a     = A(3,:);
             obj.alpha = A(4,:);
-            obj.type  = A(5,:);
+            obj.set_joint_types(A(5,:));
         end
         
     

--- a/robot_modeling/DQ_SerialManipulatorMDH.m
+++ b/robot_modeling/DQ_SerialManipulatorMDH.m
@@ -30,7 +30,7 @@
 %       set_effector - Set an arbitrary end-effector rigid transformation with respect to the last frame in the kinematic chain.
 % See also DQ_SerialManipulator.
 
-% (C) Copyright 2020-2022 DQ Robotics Developers
+% (C) Copyright 2020-2023 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %

--- a/robot_modeling/DQ_SerialManipulatorMDH.m
+++ b/robot_modeling/DQ_SerialManipulatorMDH.m
@@ -72,7 +72,6 @@
 classdef DQ_SerialManipulatorMDH < DQ_SerialManipulator
     properties
         theta,d,a,alpha;
-        type
     end
     
     properties (Constant)
@@ -107,7 +106,7 @@ classdef DQ_SerialManipulatorMDH < DQ_SerialManipulator
             half_alpha = obj.alpha(ith)/2.0;
             
             % Add the effect of the joint value
-            if obj.type(ith) == DQ_JointType.REVOLUTE
+            if obj.get_joint_type(ith) == DQ_JointType.REVOLUTE
                 % If joint is revolute
                 half_theta = half_theta + (q/2.0);
             else
@@ -142,12 +141,18 @@ classdef DQ_SerialManipulatorMDH < DQ_SerialManipulator
         % Usage: w = get_w(ith), where
         %          ith: link number
 
-            if obj.type(ith) == DQ_JointType.REVOLUTE            
+            if obj.get_joint_type(ith) == DQ_JointType.REVOLUTE            
                 w = -DQ.j*sin(obj.alpha(ith))+ DQ.k*cos(obj.alpha(ith))...
                     -DQ.E*obj.a(ith)*(DQ.j*cos(obj.alpha(ith)) + DQ.k*sin(obj.alpha(ith)));
             else % if joint is PRISMATIC          
                 w = DQ.E*(cos(obj.alpha(ith))*DQ.k - sin(obj.alpha(ith))*DQ.j);
             end
+        end
+
+
+        function ret = get_supported_joint_types(~)
+        % This method returns the supported joint types.
+            ret = [DQ_JointType.REVOLUTE, DQ_JointType.PRISMATIC];
         end
         
     end
@@ -183,7 +188,7 @@ classdef DQ_SerialManipulatorMDH < DQ_SerialManipulator
             obj.d     = A(2,:);
             obj.a     = A(3,:);
             obj.alpha = A(4,:);
-            obj.type  = A(5,:);
+            obj.set_joint_types(A(5,:));
         end
         
     end

--- a/robot_modeling/DQ_SerialManipulatorMDH.m
+++ b/robot_modeling/DQ_SerialManipulatorMDH.m
@@ -147,15 +147,17 @@ classdef DQ_SerialManipulatorMDH < DQ_SerialManipulator
             else % if joint is PRISMATIC          
                 w = DQ.E*(cos(obj.alpha(ith))*DQ.k - sin(obj.alpha(ith))*DQ.j);
             end
-        end
+        end 
+    end
 
-
-        function ret = get_supported_joint_types(~)
+    methods (Static, Access = protected) 
+         % This method returns the supported joint types.
+         function ret = get_supported_joint_types()
         % This method returns the supported joint types.
             ret = [DQ_JointType.REVOLUTE, DQ_JointType.PRISMATIC];
-        end
-        
+         end
     end
+
     methods
         function obj = DQ_SerialManipulatorMDH(A)
             % These are initialized in the constructor of


### PR DESCRIPTION
@dqrobotics/developers 

Hi @bvadorno,

This PR proposes the following modifications to fix #76 :

- Removed the public property `type`  from subclasses `DQ_SerialManipulatorDH` and `DQ_SerialManipulatorMDH`. Added the protected property `joint_types` in `DQ_SerialManipulator`.  Motivations:
  - The joint types do not depend on any specific parametrization. Therefore, `obj.joint_types` is a property common to all subclasses, like `obj.n_joints`.
  - Since we now have the method `set_joint_types` (and get_joint_types, both added in this PR) there is no need to keep `obj.joint_types` as a public property. (Currently, the user can freely get and set the property `obj.type`.
- The following methods were added in DQ_SerialManipulator:
  - get_supported_joint_types()    (protected, abstract)
  - check_joint_types()                  (public)
  - get_joint_types()                      (public)     (returns the joint types as a vector)
  - get_joint_type(ith)                        (public)  (returns only the ith joint type as a double)
  - set_joint_types()                       (public)      (sets all joints)
  - set_joint_type(ith)                        (public)   (sets only the ith joint)

UML:
<img src="https://user-images.githubusercontent.com/23158313/210493957-10b364c8-95f5-4331-b4bc-9dfbf207a0b0.png" alt="drawing" width="500"/>

Example of use:
Minimal example used in #76
```matlab
clear all;
clc;
close all;

ax18_DH_theta   = [0       0      -pi/2   -pi/2      -pi/2];  % theta
ax18_DH_d       = [0.167   0       0     0.1225          0];  % d
ax18_DH_a       = [0      0.159    0.02225    0      0.170];  % a
ax18_DH_alpha   = [-pi/2   0      -pi/2   -pi/2          0];  % alpha

R = double(DQ_JointType.REVOLUTE);
P = double(DQ_JointType.PRISMATIC);
H = double(DQ_JointType.HELICAL);
S = double(DQ_JointType.SPHERICAL);
C = double(DQ_JointType.CYLINDRICAL);
Pl = double(DQ_JointType.PLANAR);
SD = double(DQ_JointType.SIX_DOF);

ax18_DH_type    = [SD P H S C];


ax18_DH_matrix = [  ax18_DH_theta;
    ax18_DH_d;
    ax18_DH_a;
    ax18_DH_alpha;
    ax18_DH_type;
    ]; % D&H parameters matrix for the arm model

ax = DQ_SerialManipulatorDH(ax18_DH_matrix)
``` 

Output:

```txt
Error using DQ_SerialManipulator/check_joint_types
Unsupported joint types. Use valid joint types:  DQ_JointType.REVOLUTE,
DQ_JointType.PRISMATIC.

Error in DQ_SerialManipulator/set_joint_types (line 146)
            obj.check_joint_types();

Error in DQ_SerialManipulatorDH (line 196)
            obj.set_joint_types(A(5,:));

Error in untitled2 (line 30)
ax = DQ_SerialManipulatorDH(ax18_DH_matrix)

```

Best regards, 

Juancho
