### PR TITLE
Solves issue [BUG] Overloading DISPLAY is not recommended #77

### DIFF
--- a/@DQ/DQ.m
+++ b/@DQ/DQ.m
@@ -141,7 +141,7 @@ classdef DQ
         %Imaginary k
         k = DQ([0,0,0,1]);
         %Absolute values below the threshold are considered zero. This
-        %threshold is used in the following functions: display, norm, ne,
+        %threshold is used in the following functions: disp, norm, ne,
         %and eq.
         threshold = 1e-12;
         % Given the dual quaternion x, the matrix C8 is the one that

--- a/@DQ/disp.m
+++ b/@DQ/disp.m
@@ -20,14 +20,10 @@
 % Contributors to this file:
 %     Bruno Vihena Adorno - adorno@ufmg.br
 
-function display(obj)
+function disp(obj)
 
     row = size(obj,1);
     column = size(obj,2);
-    
-    disp([inputname(1),' = '])
-    
-    
     
     for i = 1:row   
         row_string= [];


### PR DESCRIPTION
Renamed display.m to disp.m and removed line that invokes `disp`.
Also changed comment in @DQ/DQ.m to refer to disp function instead of display.