### PR TITLE
This PR fixes #88

### DIFF
--- a/interfaces/vrep/robots/LBR4pVrepRobot.m
+++ b/interfaces/vrep/robots/LBR4pVrepRobot.m
@@ -107,12 +107,14 @@ classdef LBR4pVrepRobot < DQ_VrepRobot
             LBR4p_DH_d = [0.200, 0, 0.4, 0, 0.39, 0, 0];
             LBR4p_DH_a = [0, 0, 0, 0, 0, 0, 0];
             LBR4p_DH_alpha = [pi/2, -pi/2, pi/2, -pi/2, pi/2, -pi/2, 0];
+            LBR4p_DH_type = double(repmat(DQ_JointType.REVOLUTE,1,7));
             LBR4p_DH_matrix = [LBR4p_DH_theta;
                 LBR4p_DH_d;
                 LBR4p_DH_a;
-                LBR4p_DH_alpha];
+                LBR4p_DH_alpha
+                LBR4p_DH_type];
             
-            kin = DQ_SerialManipulator(LBR4p_DH_matrix,'standard');
+            kin = DQ_SerialManipulatorDH(LBR4p_DH_matrix);
             
             kin.set_reference_frame(obj.vrep_interface.get_object_pose(obj.base_frame_name));
             kin.set_base_frame(obj.vrep_interface.get_object_pose(obj.base_frame_name));

--- a/interfaces/vrep/robots/YouBotVrepRobot.m
+++ b/interfaces/vrep/robots/YouBotVrepRobot.m
@@ -131,12 +131,14 @@ classdef YouBotVrepRobot < DQ_VrepRobot
             arm_DH_d =   [  0.147,      0,       0,        0,    0.218];
             arm_DH_a =   [  0.033,  0.155,   0.135,        0,        0];
             arm_DH_alpha =   [pi2,      0,       0,      pi2,        0];
+            arm_DH_type = double(repmat(DQ_JointType.REVOLUTE,1,5));
             arm_DH_matrix = [arm_DH_theta;
                 arm_DH_d;
                 arm_DH_a;
-                arm_DH_alpha];
+                arm_DH_alpha
+                arm_DH_type];
             
-            arm =  DQ_SerialManipulator(arm_DH_matrix,'standard');
+            arm =  DQ_SerialManipulatorDH(arm_DH_matrix);
             base = DQ_HolonomicBase();
             
             x_bm = 1 + E_*0.5*(0.165*i_ + 0.11*k_);


### PR DESCRIPTION
Hi @bvadorno and @mmmarinho 

This PR fixes #88. 
I fixed both classes LBR4pVrepRobot and YouBotVrepRobot since the bug is the same. The example [matlab-examples/vrep/simulation-ram-paper/main_simulation_file.m](https://github.com/dqrobotics/matlab-examples/blob/master/vrep/simulation-ram-paper/main_simulation_file.m) runs sucessfully with this PR. 

Best regards, 

Juancho
