### PR TITLE
This PR proposes new methods for getting and setting the DH parameters.

### DIFF
--- a/robot_modeling/DQ_DHParameter.m
+++ b/robot_modeling/DQ_DHParameter.m
@@ -1,0 +1,32 @@
+% (C) Copyright 2023 DQ Robotics Developers
+%
+% This file is part of DQ Robotics.
+%
+%     DQ Robotics is free software: you can redistribute it and/or modify
+%     it under the terms of the GNU Lesser General Public License as published
+%     by the Free Software Foundation, either version 3 of the License, or
+%     (at your option) any later version.
+%
+%     DQ Robotics is distributed in the hope that it will be useful,
+%     but WITHOUT ANY WARRANTY; without even the implied warranty of
+%     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%     GNU Lesser General Public License for more details.
+%
+%     You should have received a copy of the GNU Lesser General Public License
+%     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
+%
+% DQ Robotics website: dqrobotics.github.io
+%
+% Contributors to this file:
+%
+%   1. Juan Jose Quiroz Omana (juanjqo@g.ecc.u-tokyo.ac.jp) 
+%      Responsible for the original implementation.
+%
+classdef DQ_DHParameter <  uint32
+   enumeration
+      THETA    (1)
+      D        (2)
+      A        (3)
+      ALPHA    (4)
+   end
+end

--- a/robot_modeling/DQ_SerialManipulator.m
+++ b/robot_modeling/DQ_SerialManipulator.m
@@ -792,7 +792,7 @@ function o = plot_options(robot, optin)
             % TODO
             % This part of the code assumes we are using the 
             %  DH parametrization. We need to fix it in future versions.
-            reach = reach + abs(robot.a(i)) + abs(robot.d(i));
+            reach = reach + abs(robot.get_dh_parameter("A",i)) + abs(robot.get_dh_parameter("D",i));
         end
         o.workspace = [-reach reach -reach reach -reach reach];      
     else

--- a/robot_modeling/DQ_SerialManipulatorDH.m
+++ b/robot_modeling/DQ_SerialManipulatorDH.m
@@ -204,7 +204,7 @@ classdef DQ_SerialManipulatorDH < DQ_SerialManipulator
             obj.set_joint_types(A(5,:));
         end
 
-function ret = get_dh_parameters(obj, parameterType)
+        function ret = get_dh_parameters(obj, parameterType)
             % This method returns a vector containing the DH parameters.
             % Usage: get_dh_parameters(parameterType)
             %           parameterType: Parameter type, which corresponds to

--- a/robot_modeling/DQ_SerialManipulatorMDH.m
+++ b/robot_modeling/DQ_SerialManipulatorMDH.m
@@ -28,6 +28,10 @@
 %       raw_pose_jacobian - Compute the pose Jacobian without taking into account base's and end-effector's rigid transformations.
 %       raw_pose_jacobian_derivative - Compute the pose Jacobian derivative without taking into account base's and end-effector's rigid transformations.
 %       set_effector - Set an arbitrary end-effector rigid transformation with respect to the last frame in the kinematic chain.
+%       get_dh_parameters - Return a vector containing the DH parameters.
+%       get_dh_parameter -  Return the DH parameter of the ith joint.
+%       set_dh_parameters - Set the DH parameters.
+%       set_dh_parameter -  Set the DH parameter of the ith joint.
 % See also DQ_SerialManipulator.
 
 % (C) Copyright 2020-2023 DQ Robotics Developers
@@ -64,16 +68,18 @@
 %     3. Juan Jose Quiroz Omana (juanjqo@g.ecc.u-tokyo.ac.jp)
 %        - Created this file. Implemented the case for prismatic joints
 %          in method get_w().
+%        - Added set and get methods for the DH parameters.
 
 
 
 
 
 classdef DQ_SerialManipulatorMDH < DQ_SerialManipulator
-    properties
-        theta,d,a,alpha;
+
+    properties (Access = protected)
+        dh_matrix;
     end
-    
+
     properties (Constant)
         % Joints that can be actuated
         % Rotational joint
@@ -100,10 +106,10 @@ classdef DQ_SerialManipulatorMDH < DQ_SerialManipulator
             end
             
             % Store half angles and displacements
-            half_theta = obj.theta(ith)/2.0;
-            d = obj.d(ith);
-            a = obj.a(ith);
-            half_alpha = obj.alpha(ith)/2.0;
+            half_theta = obj.get_dh_parameter("THETA", ith)/2.0;
+            d          = obj.get_dh_parameter("D",     ith);
+            a          = obj.get_dh_parameter("A",     ith);
+            half_alpha = obj.get_dh_parameter("ALPHA", ith)/2.0;
             
             % Add the effect of the joint value
             if obj.get_joint_type(ith) == DQ_JointType.REVOLUTE
@@ -140,12 +146,14 @@ classdef DQ_SerialManipulatorMDH < DQ_SerialManipulator
         % Human-Robot Collaboration' by Bruno Adorno.
         % Usage: w = get_w(ith), where
         %          ith: link number
+            alpha = obj.get_dh_parameter("ALPHA",ith);
+            a     = obj.get_dh_parameter("A", ith);
 
             if obj.get_joint_type(ith) == DQ_JointType.REVOLUTE            
-                w = -DQ.j*sin(obj.alpha(ith))+ DQ.k*cos(obj.alpha(ith))...
-                    -DQ.E*obj.a(ith)*(DQ.j*cos(obj.alpha(ith)) + DQ.k*sin(obj.alpha(ith)));
+                w = -DQ.j*sin(alpha)+ DQ.k*cos(alpha)...
+                    -DQ.E*a*(DQ.j*cos(alpha) + DQ.k*sin(alpha));
             else % if joint is PRISMATIC          
-                w = DQ.E*(cos(obj.alpha(ith))*DQ.k - sin(obj.alpha(ith))*DQ.j);
+                w = DQ.E*(cos(alpha)*DQ.k - sin(alpha)*DQ.j);
             end
         end 
     end
@@ -185,12 +193,68 @@ classdef DQ_SerialManipulatorMDH < DQ_SerialManipulator
             % TODO: change n_links to dim_configuration_space
             obj.n_links = size(A,2);
 
-            % Add theta, d, a, alpha and type
-            obj.theta = A(1,:);
-            obj.d     = A(2,:);
-            obj.a     = A(3,:);
-            obj.alpha = A(4,:);
+            obj.set_dh_parameters("THETA", A(1,:));
+            obj.set_dh_parameters("D",     A(2,:));
+            obj.set_dh_parameters("A",     A(3,:));
+            obj.set_dh_parameters("ALPHA", A(4,:));
             obj.set_joint_types(A(5,:));
+        end
+
+        function ret = get_dh_parameters(obj, parameterType)
+            % This method returns a vector containing the DH parameters.
+            % Usage: get_dh_parameters(parameterType)
+            %           parameterType: Parameter type, which corresponds to
+            %                          "THETA", "D", "A", or "ALPHA".
+            arguments
+               obj
+               parameterType DQ_DHParameter              
+            end
+            ret = obj.dh_matrix(parameterType,:);
+        end
+
+        function ret = get_dh_parameter(obj, parameterType, ith_joint)
+            % This method returns the DH parameter of the ith joint.
+            % Usage: get_dh_parameter(parameterType, ith_joint)
+            %           parameterType: Parameter type, which corresponds to
+            %                          "THETA", "D", "A", or "ALPHA".
+            %           ith_joint: Joint number.
+            arguments
+               obj
+               parameterType DQ_DHParameter 
+               ith_joint int32
+            end
+            ret = obj.dh_matrix(parameterType,ith_joint);
+        end
+
+        function set_dh_parameters(obj, parameterType, vector_parameters)
+            % This method sets the DH parameters.
+            % Usage: set_dh_parameters(parameterType, vector_parameters)
+            %           parameterType: Parameter type, which corresponds to
+            %                          "THETA", "D", "A", or "ALPHA".
+            %           vector_parameters: Vector containing the new
+            %                              parameters.
+            arguments
+               obj
+               parameterType DQ_DHParameter   
+               vector_parameters double
+            end
+            obj.dh_matrix(parameterType,:) = vector_parameters;
+        end
+
+        function set_dh_parameter(obj, parameterType, ith_joint, parameter)
+            % This method sets the DH parameter of the ith joint.
+            % Usage: set_dh_parameters(parameterType, vector_parameters)
+            %           parameterType: Parameter type, which corresponds to
+            %                          "THETA", "D", "A", or "ALPHA".
+            %           ith_joint: Joint number.
+            %           parameter: The new parameter.
+            arguments
+               obj
+               parameterType DQ_DHParameter 
+               ith_joint int32
+               parameter double
+            end
+            obj.dh_matrix(parameterType,ith_joint) = parameter;
         end
         
     end


### PR DESCRIPTION

This PR aims to discuss the design, names, styles, and so on for new methods for getting and setting the DH parameters.

I had a hard time adding enumerations inside a Matlab class. To illustrate my problem consider the following minimal example:

```matlab
classdef MyTestClass
   properties
    A;
   end
   methods
      function obj = MyTestClass(A)
         obj.A = A;
      end
   end
end
```

Usage:
```shell
>> MyTestClass(1)

ans = 

  MyTestClass with properties:

    A: 1

>>
```

Adding the enumerations in MyTestClass:

```matlab
classdef MyTestClass
   enumeration
       Theta (1), Alpha (2);
   end

   properties
    A;
   end

   methods
      function obj = MyTestClass(A)
         obj.A = A;
      end
   end
   
end
```

output:

```shell
>> MyTestClass(1)
Error using MyTestClass
Input does not correspond to a member of the enumeration class
'MyTestClass'.
```

So as not to get stuck in the same place, I created the enum class 'DQ_DHParameter',  and implemented the following methods (for both subclasses of DQ_SerialManipulator):

```matlab
function ret = get_dh_parameters(obj, parameterType)
            % This method returns a vector containing the DH parameters.
            % Usage: get_dh_parameters(parameterType)
            %           parameterType: Parameter type, which corresponds to
            %                          "THETA", "D", "A", or "ALPHA".
            arguments
               obj
               parameterType DQ_DHParameter              
            end
            ret = obj.dh_matrix(parameterType,:);
        end

        function ret = get_dh_parameter(obj, parameterType, ith_joint)
            % This method returns the DH parameter of the ith joint.
            % Usage: get_dh_parameter(parameterType, ith_joint)
            %           parameterType: Parameter type, which corresponds to
            %                          "THETA", "D", "A", or "ALPHA".
            %           ith_joint: Joint number.
            arguments
               obj
               parameterType DQ_DHParameter 
               ith_joint int32
            end
            ret = obj.dh_matrix(parameterType,ith_joint);
        end

        function set_dh_parameters(obj, parameterType, vector_parameters)
            % This method sets the DH parameters.
            % Usage: set_dh_parameters(parameterType, vector_parameters)
            %           parameterType: Parameter type, which corresponds to
            %                          "THETA", "D", "A", or "ALPHA".
            %           vector_parameters: Vector containing the new
            %                              parameters.
            arguments
               obj
               parameterType DQ_DHParameter   
               vector_parameters double
            end
            obj.dh_matrix(parameterType,:) = vector_parameters;
        end

        function set_dh_parameter(obj, parameterType, ith_joint, parameter)
            % This method sets the DH parameter of the ith joint.
            % Usage: set_dh_parameters(parameterType, vector_parameters)
            %           parameterType: Parameter type, which corresponds to
            %                          "THETA", "D", "A", or "ALPHA".
            %           ith_joint: Joint number.
            %           parameter: The new parameter.
            arguments
               obj
               parameterType DQ_DHParameter 
               ith_joint int32
               parameter double
            end
            obj.dh_matrix(parameterType,ith_joint) = parameter;
        end

```

Example of use:


