### PR TITLE
This PR adds the property dim_configuration_space in the superclass DQ_Kinematics

### DIFF
--- a/robot_modeling/DQ_FreeFlyingRobot.m
+++ b/robot_modeling/DQ_FreeFlyingRobot.m
@@ -16,7 +16,7 @@
 %
 %       See also DQ_MobileBase, DQ_DifferentialDriveRobot, DQ_HolonomicBase
 
-% (C) Copyright 2011-2020 DQ Robotics Developers
+% (C) Copyright 2011-2023 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %

--- a/robot_modeling/DQ_FreeFlyingRobot.m
+++ b/robot_modeling/DQ_FreeFlyingRobot.m
@@ -45,7 +45,6 @@ classdef DQ_FreeFlyingRobot < DQ_Kinematics
     end
     
     properties (Access = private)
-        dim_configuration_space;
         shape_template;
         handle;
     end

--- a/robot_modeling/DQ_Kinematics.m
+++ b/robot_modeling/DQ_Kinematics.m
@@ -74,6 +74,8 @@ classdef DQ_Kinematics < handle
         base_frame;
         % Robot configuration vector
         q; 
+        % Dimension of the configuration space
+        dim_configuration_space;
     end
     
     methods

--- a/robot_modeling/DQ_Kinematics.m
+++ b/robot_modeling/DQ_Kinematics.m
@@ -36,7 +36,7 @@
 %       translation_jacobian - Compute the translation Jacobian.
 % See also DQ_SerialManipulator, DQ_MobileBase, DQ_CooperativeDualTaskSpace.
 
-% (C) Copyright 2011-2022 DQ Robotics Developers
+% (C) Copyright 2011-2023 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %
@@ -56,7 +56,11 @@
 % DQ Robotics website: dqrobotics.github.io
 %
 % Contributors to this file:
-%     Bruno Vihena Adorno - adorno@ieee.org
+%     1. Bruno Vihena Adorno (adorno@ieee.org)
+%          Responsible for the original implementation. 
+%
+%     2. Juan Jose Quiroz Omana (juanjqo@g.ecc.u-tokyo.ac.jp)
+%        - Added the property dim_configuration_space. 
 
 classdef DQ_Kinematics < handle
     % DQ_Kinematics inherits the HANDLE superclass to avoid unnecessary copies

--- a/robot_modeling/DQ_MobileBase.m
+++ b/robot_modeling/DQ_MobileBase.m
@@ -18,7 +18,7 @@
 %
 % See also DQ_Kinematics, DQ_HolonomicBase.
 
-% (C) Copyright 2011-2019 DQ Robotics Developers
+% (C) Copyright 2011-2023 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %
@@ -38,7 +38,7 @@
 % DQ Robotics website: dqrobotics.github.io
 %
 % Contributors to this file:
-%     Bruno Vihena Adorno - adorno@ufmg.br
+%     Bruno Vihena Adorno - adorno@ieee.org
 
 classdef (Abstract) DQ_MobileBase < DQ_Kinematics
     properties      

--- a/robot_modeling/DQ_MobileBase.m
+++ b/robot_modeling/DQ_MobileBase.m
@@ -47,7 +47,6 @@ classdef (Abstract) DQ_MobileBase < DQ_Kinematics
     
     properties (Access = protected)
         handle;
-        dim_configuration_space;
         frame_displacement;
     end
     

--- a/robot_modeling/DQ_SerialManipulator.m
+++ b/robot_modeling/DQ_SerialManipulator.m
@@ -35,7 +35,12 @@
 % DQ Robotics website: dqrobotics.github.io
 %
 % Contributors to this file:
-%     Bruno Vihena Adorno - adorno@ieee.org
+%     1. Bruno Vihena Adorno - adorno@ieee.org
+%          Responsible for the original implementation. 
+%
+%     2. Juan Jose Quiroz Omana (juanjqo@g.ecc.u-tokyo.ac.jp)
+%        - Removed the property n_links. The dimension of the configuration
+%          space is now stored in DQ_Kinematics.dim_configuration_space.
 
 classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
     properties        

--- a/robot_modeling/DQ_SerialManipulator.m
+++ b/robot_modeling/DQ_SerialManipulator.m
@@ -50,7 +50,6 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
         % Handle used to access the robot's graphics information. It's used
         % mainly in the plot function.
         handle
-        n_links;
         joint_types;
     end
 
@@ -133,7 +132,7 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
         end
         
         function ret = get_dim_configuration_space(obj)
-            ret = obj.n_links;
+            ret = obj.dim_configuration_space;
         end
         
         function set_effector(obj,effector)
@@ -214,7 +213,7 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
             if nargin == 3
                 n = to_ith_link;
             else
-                n = obj.n_links;
+                n = obj.get_dim_configuration_space();
             end
             
             x = DQ(1);
@@ -239,7 +238,7 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
             % internally in DQ_kinematics
             
             if nargin < 3
-                to_ith_link = obj.n_links;
+                to_ith_link = obj.get_dim_configuration_space();
             end
             x_effector = obj.raw_fkm(q,to_ith_link);
             
@@ -272,7 +271,7 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
                 J = obj.raw_pose_jacobian(q,to_ith_link);
                 vec_x_effector_dot = J*q_dot(1:to_ith_link);
             else
-                n = obj.n_links;
+                n = obj.get_dim_configuration_space();
                 % obj.check_to_ith_link(n);
                 x_effector = obj.raw_fkm(q);
                 J = obj.raw_pose_jacobian(q);
@@ -314,7 +313,7 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
             % both base and end-effector displacements (their default
             % values are 1).
             
-            if nargin == 3 && ith < obj.n_links
+            if nargin == 3 && ith < obj.get_dim_configuration_space()
                 % If the Jacobian is not related to the mapping between the
                 % end-effector velocities and the joint velocities, it takes
                 % into account only the constant base displacement
@@ -338,7 +337,7 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
             % This function does not take into account any base or
             % end-effector displacements.
             
-            if nargin == 4 && ith < obj.n_links
+            if nargin == 4 && ith < obj.get_dim_configuration_space()
                 % If the Jacobian derivative is not related to the mapping between the
                 % end-effector velocities and the joint velocities, it takes
                 % into account only the constant base displacement
@@ -463,7 +462,7 @@ function dq_kinematics_plot(robot, q, varargin)
         opt = plot_options(robot, varargin);
     end
 
-    n = robot.n_links;
+    n = robot.get_dim_configuration_space();
 
     if length(q) ~= n
         error('Incorrect number of joints. The correct number is %d', n);
@@ -591,7 +590,7 @@ function h = create_new_robot(robot, opt)
     end
 
     % Display cylinders (revolute each joint).
-    for i = 1:robot.n_links
+    for i = 1:robot.get_dim_configuration_space()
         if opt.joints
             %TODO: implement prismatic joints
             N = 8;
@@ -641,7 +640,7 @@ end
 % kinematic robot, and graphics are defined by the handle structure robot.handle, 
 % which stores the 'graphical robot' as robot.handle.robot.
 function update_robot(robot, q)
-    n = robot.n_links;
+    n = robot.get_dim_configuration_space();
     
     % Get the handle to the graphical robot. Since each kinematic robot
     % stores just one graphical handle, if we want to plot the same robot
@@ -785,7 +784,7 @@ function o = plot_options(robot, optin)
     % simple heuristic to figure the maximum reach of the robot
     if isempty(o.workspace)
         reach = 0;
-        for i=1:robot.n_links
+        for i=1:robot.get_dim_configuration_space()
             % Since the maximum reaching distance are given by the link offset 
             % and link length, we add them.
 

--- a/robot_modeling/DQ_SerialManipulatorDH.m
+++ b/robot_modeling/DQ_SerialManipulatorDH.m
@@ -185,10 +185,8 @@ classdef DQ_SerialManipulatorDH < DQ_SerialManipulator
             if(size(A,1) ~= 5)
                 error('Input: Invalid DH matrix. It must have 5 rows.')
             end
-
-            % n_links 
-            % TODO: change n_links to dim_configuration_space
-            obj.n_links = size(A,2);
+            
+            obj.dim_configuration_space = size(A,2);
 
             % Add theta, d, a, alpha and type
             obj.theta = A(1,:);

--- a/robot_modeling/DQ_SerialManipulatorMDH.m
+++ b/robot_modeling/DQ_SerialManipulatorMDH.m
@@ -181,9 +181,7 @@ classdef DQ_SerialManipulatorMDH < DQ_SerialManipulator
                 error('Input: Invalid modified DH matrix. It must have 5 rows.')
             end
 
-            % n_links 
-            % TODO: change n_links to dim_configuration_space
-            obj.n_links = size(A,2);
+            obj.dim_configuration_space = size(A,2);
 
             % Add theta, d, a, alpha and type
             obj.theta = A(1,:);

--- a/robot_modeling/DQ_SerialWholeBody.m
+++ b/robot_modeling/DQ_SerialWholeBody.m
@@ -86,7 +86,6 @@ classdef DQ_SerialWholeBody < DQ_Kinematics
         % fkm of chain{ith} is its conjugate and the corresponding pose_jacobian is
         % DQ.C8*J.
         reversed;
-        dim_configuration_space;
     end
     
     methods

--- a/robot_modeling/DQ_SerialWholeBody.m
+++ b/robot_modeling/DQ_SerialWholeBody.m
@@ -51,7 +51,7 @@
 %
 % See also DQ_kinematics, DQ_MobileBase
 
-% (C) Copyright 2011-2019 DQ Robotics Developers
+% (C) Copyright 2011-2023 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %
@@ -71,7 +71,7 @@
 % DQ Robotics website: dqrobotics.github.io
 %
 % Contributors to this file:
-%     Bruno Vihena Adorno - adorno@ufmg.br
+%     Bruno Vihena Adorno - adorno@ieee.org
 
 classdef DQ_SerialWholeBody < DQ_Kinematics
     properties (Access = protected)

--- a/robot_modeling/DQ_WholeBody.m
+++ b/robot_modeling/DQ_WholeBody.m
@@ -77,7 +77,6 @@ classdef DQ_WholeBody < DQ_Kinematics
         % fkm of chain{ith} is its conjugate and the corresponding pose_jacobian is
         % DQ.C8*J.
         reversed;
-        dim_configuration_space;
     end
     
     methods

--- a/robot_modeling/DQ_WholeBody.m
+++ b/robot_modeling/DQ_WholeBody.m
@@ -42,7 +42,7 @@
 %
 % See also DQ_kinematics, DQ_MobileBase
 
-% (C) Copyright 2011-2019 DQ Robotics Developers
+% (C) Copyright 2011-2023 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %
@@ -62,7 +62,7 @@
 % DQ Robotics website: dqrobotics.github.io
 %
 % Contributors to this file:
-%     Bruno Vihena Adorno - adorno@ufmg.br
+%     Bruno Vihena Adorno -  adorno@ieee.org
 
 classdef DQ_WholeBody < DQ_Kinematics
     properties (Access = protected)


### PR DESCRIPTION
@dqrobotics/developers 

Hi @bvadorno and @mmmarinho ,

This PR adds the property `dim_configuration_space` in the superclass `DQ_Kinematics`. This modification is inspired by the current [C++ ](https://github.com/dqrobotics/cpp/blob/master/include/dqrobotics/robot_modeling/DQ_Kinematics.h) implementation and aims to advance a step toward the convergence of both versions of DQ Robotics. 

Motivation:

All subclasses of the superclass `DQ_Kinematics` implement the property `dim_configuration_space`. Since the configuration space size is a common property of all subclasses, it looks reasonable to implement it in the superclass directly. 

List of modifications:

- Added `dim_configuration_space` in `DQ_Kinematics`.
- Removed `dim_configuration_space` from the following classes:
    - `DQ_MobileBase`
    - `DQ_SerialWholeBody`
    - `DQ_FreeFlyingRobot`
    - `DQ_WholeBody`
- ![](https://img.shields.io/badge/-warning-yellow) I removed `n_links` from `DQ_SerialManipulator`. Consequently, I modified internal implementations of the class and its subclasses to comply this change.  For example, in `DQ_Serialmanipulator` the parts using n_links were updated. 
This is, 

Current Master Branch:
```matlab
n = robot.n_links;
```
Current PR:
```matlab
n = robot.get_dim_configuration_space();
```
The only modification required in the subclasses of `DQ_SerialManipulator` was the following:
Current master branch:
```matlab
obj.n_links = size(A,2);
```
This PR:
```matlab
obj.dim_configuration_space = size(A,2);
```
I tried to avoid those internal modifications as much as possible, as suggested/pointed out by  [Bruno](https://github.com/dqrobotics/matlab/pull/69#issuecomment-1327187436) and [Murilo](https://github.com/dqrobotics/matlab/pull/93#issuecomment-1510524227). Nevertheless, I think it would be weird to have `n_links` only in one of the subclasses of `DQ_Kinematics` acting as a local `dim_configuration_space`.  
_____

Current Master Branch:
<img src="https://user-images.githubusercontent.com/23158313/233829120-bd110224-545e-4f29-9814-3fe71b721c37.png" alt="drawing" width="800"/>

Proposal in this PR:
<img src="https://user-images.githubusercontent.com/23158313/233829026-1a024034-af3d-444d-8ad7-28295c6b5c49.png" alt="drawing" width="800"/>

Please let me know what do you think.

Best regards, 

Juancho



