### PR TITLE
[DQ_VrepInterface.m] This PR improves the documentation.

### DIFF
--- a/interfaces/vrep/DQ_VrepInterface.m
+++ b/interfaces/vrep/DQ_VrepInterface.m
@@ -284,9 +284,8 @@ classdef DQ_VrepInterface < handle
             % opmode, it is chosen first as STREAMING and then as BUFFER,
             % as specified by the remote API documentation
             
-            handle = objectname;
-            relative_to_handle = reference_frame;
-
+            handle = objectname; % aliase
+            
             if nargin <= 2
                 element = obj.element_from_string(handle);
                 if(~element.state_from_function_signature('get_object_translation'))
@@ -313,6 +312,7 @@ classdef DQ_VrepInterface < handle
                         obj.OP_BUFFER);
                 end
             else
+                relative_to_handle = reference_frame; % aliase
                 [~,object_position]  = obj.vrep.simxGetObjectPosition(...
                     obj.clientID,...
                     obj.handle_from_string_or_handle(handle),...
@@ -338,10 +338,10 @@ classdef DQ_VrepInterface < handle
             %      t = DQ.i*0.01;
             %      set_object_translation('DefaultCamera', t);
 
+            % Create some aliases
             handle = objectname;
             t = translation;
-            relative_to_handle = reference_frame;
-            
+  
             if nargin == 3
                 obj.vrep.simxSetObjectPosition(obj.clientID,...
                     obj.handle_from_string_or_handle(handle),...
@@ -349,6 +349,7 @@ classdef DQ_VrepInterface < handle
                     t.q(2:4),...
                     obj.OP_ONESHOT);
             else
+                relative_to_handle = reference_frame; % aliase
                 obj.vrep.simxSetObjectPosition(obj.clientID,...
                     obj.handle_from_string_or_handle(handle),...
                     obj.handle_from_string_or_handle(relative_to_handle),...
@@ -374,8 +375,6 @@ classdef DQ_VrepInterface < handle
             
             % Create some aliases
             handle = objectname;
-            relative_to_handle = reference_frame;
-
             id = obj.clientID;
             handle1 = obj.handle_from_string_or_handle(handle);
             
@@ -406,6 +405,7 @@ classdef DQ_VrepInterface < handle
                         obj.OP_BUFFER);
                 end
             else
+                relative_to_handle = reference_frame; % aliase
                 handle2 = obj.handle_from_string_or_handle(relative_to_handle);
                 [~,obj_rot] = obj.vrep.simxGetObjectQuaternion(id,...
                     handle1,...
@@ -438,10 +438,10 @@ classdef DQ_VrepInterface < handle
             %      r = DQ.i;
             %      set_object_rotation('DefaultCamera', r);
  
+            % create some aliases
             handle = objectname;
             r = rotation;
-            relative_to_handle = reference_frame;
-
+            
             if nargin == 3
                 obj.vrep.simxSetObjectQuaternion(...
                     obj.clientID,...
@@ -450,6 +450,7 @@ classdef DQ_VrepInterface < handle
                     [r.q(2:4); r.q(1)],...
                     obj.OP_ONESHOT); %V-Rep's quaternion representation is [x y z w] so we have to take that into account
             else
+                relative_to_handle = reference_frame; % aliase
                 obj.vrep.simxSetObjectQuaternion(...
                     obj.clientID,...
                     obj.handle_from_string_or_handle(handle),...
@@ -474,13 +475,14 @@ classdef DQ_VrepInterface < handle
             % Example:
             %      r = get_object_pose('DefaultCamera');
 
-            handle = objectname;
-            relative_to_handle = reference_frame;
+            handle = objectname; % aliase
+            
 
             if nargin <= 2
                 t = obj.get_object_translation(handle);
                 r = obj.get_object_rotation(handle);
             else
+                relative_to_handle = reference_frame; % aliase
                 t = obj.get_object_translation(...
                     obj.handle_from_string_or_handle(handle),...
                     obj.handle_from_string_or_handle(relative_to_handle),...
@@ -511,9 +513,9 @@ classdef DQ_VrepInterface < handle
             %      x = r+0.5*DQ.E*t*r;
             %      set_object_pose('DefaultCamera', x);
  
+            % create some aliases
             handle = objectname;
-            x = pose;
-            relative_to_handle = reference_frame;
+            x = pose;            
 
             if nargin == 3
                 t = translation(x);
@@ -529,6 +531,7 @@ classdef DQ_VrepInterface < handle
                     -1,...
                     obj.OP_ONESHOT);
             else
+                relative_to_handle = reference_frame;
                 t = translation(x);
                 r = rotation(x);
                 obj.set_object_translation(...
@@ -561,6 +564,7 @@ classdef DQ_VrepInterface < handle
             %       u = [0.1 0.1 0.1 0.1 0.1 0.1 0.1];
             %       set_joint_positions(jointnames, u);
             
+            % create some aliases
             handles = jointnames;
             thetas = joint_positions;
 
@@ -604,6 +608,7 @@ classdef DQ_VrepInterface < handle
             %       u = [0.1 0.1 0.1 0.1 0.1 0.1 0.1];
             %       set_joint_target_positions(jointnames, u);     
             
+            % create some aliases
             handles = jointnames;
             thetas = joint_target_positions;
 
@@ -629,7 +634,7 @@ classdef DQ_VrepInterface < handle
             end            
         end
         
-        %% Get Joint Positions
+        
         function [joint_positions,retval]=get_joint_positions(obj,jointnames,opmode)
             % This method gets the joint positions of a robot in the server.
             % Usage:
@@ -646,9 +651,10 @@ classdef DQ_VrepInterface < handle
             %                  'LBR4p_joint5','LBR4p_joint6','LBR4p_joint7'};
             %      joint_positions = get_joint_positions(jointnames);
 
+            % create some aliases
             handles = jointnames;    
-
             thetas = zeros(length(handles),1);
+
             for joint_index=1:length(handles)
                 % First approach to the auto-management using
                 % DQ_VrepInterfaceMapElements. If the user does not specify the
@@ -742,7 +748,7 @@ classdef DQ_VrepInterface < handle
                         obj.JOINT_VELOCITY_PARAMETER_ID,...
                         opmode);
                 end
-                joint_velocities(joint_index) = double(tmp);
+                joint_velocities(joint_index) = double(tmp); 
             end
         end 
 

--- a/interfaces/vrep/DQ_VrepInterface.m
+++ b/interfaces/vrep/DQ_VrepInterface.m
@@ -93,6 +93,8 @@
 %             - wait_for_simulation_step_to_end()
 %             - set_joint_target_velocities()
 %             - get_joint_velocities()
+%
+%        - Improved the documentation of the class
 
 classdef DQ_VrepInterface < handle
     
@@ -152,7 +154,16 @@ classdef DQ_VrepInterface < handle
         end
         
         function connect(obj,ip,port)
-            %% Connects to a V-REP remote API server on a given ip and port
+            % This method connects to the remote api server (i.e. CoppeliaSim).
+            % Calling this function is required before anything else can happen.
+            % Usage:
+            %     connect(ip, port);  
+            %          ip:  The ip address where the CoppeliaSim is located.
+            %          port: The port number where to connect.
+            %
+            % Example:
+            %      connect('127.0.0.1', 19997);
+
             obj.clientID = obj.vrep.simxStart(ip,port,true,true,5000,5);
             if (obj.clientID>-1)
                 disp('Connected to the remote API server');
@@ -161,15 +172,17 @@ classdef DQ_VrepInterface < handle
             end
         end
         
-        %% Close
+      
         function disconnect(obj)
-            %% Disconnects from the V-REP remote API server
+            % This method ends the communication between the client and
+            % the server. This should be the very last method called.
             obj.vrep.simxFinish(obj.clientID);
         end
         
-        %% Close all
+        
         function disconnect_all(obj)
-            %% Flushes all V-REP remote API connections from the server
+            % This method ends all running communication threads with the 
+            % server. This should be the very last method called.
             obj.vrep.simxFinish(-1);
         end
 
@@ -199,21 +212,29 @@ classdef DQ_VrepInterface < handle
             [~, ping_time] =  obj.vrep.simxGetPingTime(obj.clientID);
         end
         
-        %% Start Simulation
+        
         function start_simulation(obj)
-            %% Starts the V-REP simulation
+            % This method starts the server simulation.
             obj.vrep.simxStartSimulation(obj.clientID,obj.vrep.simx_opmode_oneshot);
         end
         
-        %% Stop Simulation
+        
         function stop_simulation(obj)
-            %% Stops the V-REP simulation
+            % This method stops the server simulation.
             obj.vrep.simxStopSimulation(obj.clientID,obj.vrep.simx_opmode_blocking);
         end
         
-        %% Get Handles
+        
         function handles = get_handles(obj,names)
-            %% Get the V-REP handles for a cell array of object names
+            % This method gets the server handles for a cell array of 
+            % object names.
+            % Usage:
+            %     get_handles(names);  
+            %          names: The cell array of object names.
+            %
+            % Example: 
+            %     handle = get_handles({'ReferenceFrame_1', 'ReferenceFrame_2'});
+
             handles = [];
             if(iscell(names))
                 for i=1:length(names)
@@ -227,24 +248,45 @@ classdef DQ_VrepInterface < handle
             end
         end
         
-        %% Get Handle
+        
         function handle = get_handle(obj,name)
-            %% Get the V-REP handle for a given object
+            % This method gets the server handle for a given object. 
+            % object names.
+            % Usage:
+            %     get_handles(name);  
+            %          names: The object name.
+            % Example: 
+            %     handle = get_handle('ReferenceFrame');
+
             [~,handle] = obj.vrep.simxGetObjectHandle(...
                 obj.clientID,...
                 name,...
                 obj.vrep.simx_opmode_blocking);
         end
         
-        %% Get Object Translation
-        function t = get_object_translation(obj,handle,relative_to_handle,opmode)
-            %% Get the translation of an object in V-REP
-            %%  >> t = vi.get_object_translation('DefaultCamera');
+        
+        function t = get_object_translation(obj,objectname,reference_frame,opmode)
+            % This method gets the translation of an object in the server
+            %
+            % Usage:
+            %     t = get_object_translation(objectname,reference_frame,opmode);  
+            %          objectname:  The object name
+            %          (optional) reference_frame:  Indicates the name of 
+            %                       the relative reference frame in which you 
+            %                       want the translation. If not specified, 
+            %                       the absolute frame is used.
+            %          (optional) opmode:The operation mode.             
+            % Example:
+            %      t = get_object_translation('DefaultCamera');
             
             % First approach to the auto-management using
             % DQ_VrepInterfaceMapElements. If the user does not specify the
             % opmode, it is chosen first as STREAMING and then as BUFFER,
             % as specified by the remote API documentation
+            
+            handle = objectname;
+            relative_to_handle = reference_frame;
+
             if nargin <= 2
                 element = obj.element_from_string(handle);
                 if(~element.state_from_function_signature('get_object_translation'))
@@ -280,11 +322,25 @@ classdef DQ_VrepInterface < handle
             t = DQ([0,double(object_position)]);
         end
         
-        %% Set Object Translation
-        function set_object_translation(obj,handle,t,relative_to_handle,opmode)
-            %% Set the translation of an object in V-REP
-            %%  >> t = DQ.i*0.01;
-            %%  >> vi.set_object_translation('DefaultCamera',t);
+        
+        function set_object_translation(obj,objectname,translation,reference_frame,opmode)
+            % This method sets the translation of an object in the server.
+            % Usage:
+            %     set_object_translation(objectname,translation,reference_frame,opmode);  
+            %          objectname:  The object name.
+            %          translation: The desired translation. 
+            %          (optional) reference_frame:  Indicates the name of 
+            %                       the relative reference frame in which 
+            %                       the desired translation is expressed. 
+            %                       If not specified, the absolute frame is used.
+            %          (optional) opmode:The operation mode.
+            % Example:
+            %      t = DQ.i*0.01;
+            %      set_object_translation('DefaultCamera', t);
+
+            handle = objectname;
+            t = translation;
+            relative_to_handle = reference_frame;
             
             if nargin == 3
                 obj.vrep.simxSetObjectPosition(obj.clientID,...
@@ -301,12 +357,25 @@ classdef DQ_VrepInterface < handle
             end
         end
         
-        %% Get Object Rotation
-        function r = get_object_rotation(obj, handle, relative_to_handle, opmode)
-            %% Get the rotation of an object in V-REP
-            %%  >> r = vi.get_object_rotation('DefaultCamera');
+        
+        function r = get_object_rotation(obj, objectname, reference_frame, opmode)
+            % This method gets the rotation of an object in the server.
+            %
+            % Usage:
+            %     t = get_object_rotation(objectname,reference_frame,opmode);  
+            %          objectname: The object name
+            %          (optional) reference_frame:  Indicates the name of 
+            %                       the relative reference frame in which you 
+            %                       want the rotation. If not specified, 
+            %                       the absolute frame is used.
+            %          (optional) opmode:The operation mode.             
+            % Example:
+            %      r = get_object_rotation('DefaultCamera');
             
             % Create some aliases
+            handle = objectname;
+            relative_to_handle = reference_frame;
+
             id = obj.clientID;
             handle1 = obj.handle_from_string_or_handle(handle);
             
@@ -353,12 +422,26 @@ classdef DQ_VrepInterface < handle
                 object_rotation_double(3)]));
         end
         
-        %% Set Object Rotation
-        function set_object_rotation(obj,handle,r,relative_to_handle,opmode)
-            %% Set the rotation of an object in V-REP
-            %%  >> r = DQ.i;
-            %%  >> vi.set_object_rotation('DefaultCamera',r);
-            
+        
+        function set_object_rotation(obj,objectname,rotation,reference_frame,opmode)
+            % This method sets the rotation of an object in the server.
+            % Usage:
+            %     set_object_rotation(objectname,rotation,reference_frame,opmode);  
+            %          objectname: The object name.
+            %          rotation: The desired rotation. 
+            %          (optional) reference_frame:  Indicates the name of 
+            %                       the relative reference frame in which 
+            %                       the desired rotation is expressed. 
+            %                       If not specified, the absolute frame is used.
+            %          (optional) opmode:The operation mode.
+            % Example:
+            %      r = DQ.i;
+            %      set_object_rotation('DefaultCamera', r);
+ 
+            handle = objectname;
+            r = rotation;
+            relative_to_handle = reference_frame;
+
             if nargin == 3
                 obj.vrep.simxSetObjectQuaternion(...
                     obj.clientID,...
@@ -376,11 +459,24 @@ classdef DQ_VrepInterface < handle
             end
         end
         
-        %% Get Object Pose
-        function x = get_object_pose(obj,handle,relative_to_handle,opmode)
-            %% Get the pose of an object in V-REP
-            %%  >> x = vi.get_object_pose('DefaultCamera');
-            
+        
+        function x = get_object_pose(obj,objectname,reference_frame,opmode)
+            % This method gets the pose of an object in the server.
+            %
+            % Usage:
+            %     t = get_object_pose(objectname,reference_frame,opmode);  
+            %          objectname: The object name
+            %          (optional) reference_frame:  Indicates the name of 
+            %                       the relative reference frame in which you 
+            %                       want the pose. If not specified, 
+            %                       the absolute frame is used.
+            %          (optional) opmode:The operation mode.             
+            % Example:
+            %      r = get_object_pose('DefaultCamera');
+
+            handle = objectname;
+            relative_to_handle = reference_frame;
+
             if nargin <= 2
                 t = obj.get_object_translation(handle);
                 r = obj.get_object_rotation(handle);
@@ -397,13 +493,28 @@ classdef DQ_VrepInterface < handle
             x = r + 0.5*DQ.E*t*r;
         end
         
-        %% Set Object Pose
-        function set_object_pose(obj,handle,x,relative_to_handle,opmode)
-            %% Set the pose of an object in V-REP
-            %%  >> t = DQ.i*0.01;
-            %%  >> r = DQ.i;
-            %%  >> x = r+0.5*DQ.E*t*r;
-            
+        
+        function set_object_pose(obj,objectname,pose,reference_frame,opmode)
+            % This method sets the pose of an object in the server.
+            % Usage:
+            %     set_object_pose(objectname,pose,reference_frame,opmode);  
+            %          objectname: The object name.
+            %          pose: The desired pose. 
+            %          (optional) reference_frame:  Indicates the name of 
+            %                       the relative reference frame in which 
+            %                       the desired pose is expressed. 
+            %                       If not specified, the absolute frame is used.
+            %          (optional) opmode:The operation mode.
+            % Example:
+            %      t = DQ.i*0.01;
+            %      r = DQ.i;
+            %      x = r+0.5*DQ.E*t*r;
+            %      set_object_pose('DefaultCamera', x);
+ 
+            handle = objectname;
+            x = pose;
+            relative_to_handle = reference_frame;
+
             if nargin == 3
                 t = translation(x);
                 r = rotation(x);
@@ -433,12 +544,26 @@ classdef DQ_VrepInterface < handle
             end
         end
         
-        %% Set Joint Positions
-        function set_joint_positions(obj,handles,thetas,opmode)
-            %% Set the joint positions of a robot in V-REP. For joints that are in 'Passive Mode' in V-REP
-            %%  >> joint_names = {'redundantRob_joint1','redundantRob_joint2','redundantRob_joint3','redundantRob_joint4','redundantRob_joint5','redundantRob_joint6','redundantRob_joint7'};
-            %%  >> vi.set_joint_positions(joint_names,[0 pi/2 0 pi/2 0 pi/2 0]);
+        
+        function set_joint_positions(obj,jointnames,joint_positions,opmode)
+            % This method sets the joint positions of a robot in the server.
+            % It is required a dynamics disabled scene. 
+            %
+            % Usage:
+            %      set_joint_positions(jointnames, joint_positions, opmode)   
+            %          jointnames: The joint names.
+            %          joint_positions: The joint positions.
+            %          (optional) opmode: The operation mode.
+            %
+            % Example:
+            %      jointnames={'LBR4p_joint1','LBR4p_joint2','LBR4p_joint3','LBR4p_joint4',...
+            %                  'LBR4p_joint5','LBR4p_joint6','LBR4p_joint7'};
+            %       u = [0.1 0.1 0.1 0.1 0.1 0.1 0.1];
+            %       set_joint_positions(jointnames, u);
             
+            handles = jointnames;
+            thetas = joint_positions;
+
             if nargin == 3
                 % The recommended mode is OP_ONESHOT
                 opmode = obj.OP_ONESHOT;
@@ -461,12 +586,27 @@ classdef DQ_VrepInterface < handle
             end
         end
         
-        %% Set Joint Target Positions
-        function set_joint_target_positions(obj,handles,thetas,opmode)
-            %% Set the joint target positions of a robot in V-REP. For joints that are in 'Force/Torque Mode' in V-REP
-            %%  >> joint_names = {'redundantRob_joint1','redundantRob_joint2','redundantRob_joint3','redundantRob_joint4','redundantRob_joint5','redundantRob_joint6','redundantRob_joint7'};
-            %%  >> vi.set_joint_target_positions(joint_names,[0 pi/2 0 pi/2 0 pi/2 0]);     
+        
+        function set_joint_target_positions(obj,jointnames,joint_target_positions,opmode)
+            % This method sets the joint target positions of a robot in the server. 
+            % It is required a dynamics enabled scene, and joints in dynamic mode 
+            % with position control mode.
+            %
+            % Usage:
+            %      set_joint_target_positions(jointnames, joint_target_positions, opmode)   
+            %          jointnames: The joint names.
+            %          joint_target_positions: The joint target positions.
+            %          (optional) opmode: The operation mode.
+            %
+            % Example:
+            %       jointnames={'LBR4p_joint1','LBR4p_joint2','LBR4p_joint3','LBR4p_joint4',...
+            %                  'LBR4p_joint5','LBR4p_joint6','LBR4p_joint7'};
+            %       u = [0.1 0.1 0.1 0.1 0.1 0.1 0.1];
+            %       set_joint_target_positions(jointnames, u);     
             
+            handles = jointnames;
+            thetas = joint_target_positions;
+
             if nargin == 3
                 % The recommended mode is OP_ONESHOT
                 opmode = obj.OP_ONESHOT;
@@ -490,11 +630,24 @@ classdef DQ_VrepInterface < handle
         end
         
         %% Get Joint Positions
-        function [thetas,retval]=get_joint_positions(obj,handles,opmode)
-            %% Get joint positions
-            %%  >> joint_names = {'redundantRob_joint1','redundantRob_joint2','redundantRob_joint3','redundantRob_joint4','redundantRob_joint5','redundantRob_joint6','redundantRob_joint7'};
-            %%  >> vi.get_joint_positions(joint_names)
-            
+        function [joint_positions,retval]=get_joint_positions(obj,jointnames,opmode)
+            % This method gets the joint positions of a robot in the server.
+            % Usage:
+            %      [joint_positions, retval] = get_joint_positions(jointnames, opmode)   
+            %          jointnames: The joint names.
+            %          (optional) opmode: The operation mode.
+            %          joint_positions: The joints positions
+            %          retval: The return code of the Remote API function, 
+            %                  which is defined in https://www.coppeliarobotics.com/helpFiles/en/remoteApiConstants.htm#functionErrorCodes
+            %       
+            %
+            % Example:
+            %      jointnames={'LBR4p_joint1','LBR4p_joint2','LBR4p_joint3','LBR4p_joint4',...
+            %                  'LBR4p_joint5','LBR4p_joint6','LBR4p_joint7'};
+            %      joint_positions = get_joint_positions(jointnames);
+
+            handles = jointnames;    
+
             thetas = zeros(length(handles),1);
             for joint_index=1:length(handles)
                 % First approach to the auto-management using
@@ -533,20 +686,21 @@ classdef DQ_VrepInterface < handle
                 end
                 thetas(joint_index) = double(tmp);
             end
+            joint_positions = thetas;
         end
 
 
        function joint_velocities = get_joint_velocities(obj,jointnames,opmode)
-            % This method gets the joint velocities.
+            % This method gets the joint velocities of a robot in the server.
             % Usage:
             %      joint_velocities = get_joint_velocities(jointnames, opmode)   
             %          jointnames: The joint names.
             %          (optional) opmode: The operation mode.
             %
             % Example:
-            % jointnames={'LBR4p_joint1','LBR4p_joint2','LBR4p_joint3','LBR4p_joint4',...
-            %             'LBR4p_joint5','LBR4p_joint6','LBR4p_joint7'};
-            % joint_velocities = get_joint_velocities(jointnames);
+            %      jointnames={'LBR4p_joint1','LBR4p_joint2','LBR4p_joint3','LBR4p_joint4',...
+            %                  'LBR4p_joint5','LBR4p_joint6','LBR4p_joint7'};
+            %      joint_velocities = get_joint_velocities(jointnames);
 
             joint_velocities = zeros(length(jointnames),1);
             for joint_index=1:length(jointnames)
@@ -593,9 +747,9 @@ classdef DQ_VrepInterface < handle
         end 
 
         function set_joint_target_velocities(obj,jointnames,joint_target_velocities,opmode)
-            % This method sets the joint velocities. It is required a
-            % dynamics enabled scene, and joints in dynamic mode with velocity
-            % control mode.
+            % This method sets the joint velocities of a robot in the server.
+            % It is required a dynamics enabled scene, and joints in dynamic mode 
+            % with velocity control mode.
             %
             % Usage:
             %      set_joint_target_velocities(jointnames, joint_target_velocities, opmode)   
@@ -604,10 +758,10 @@ classdef DQ_VrepInterface < handle
             %          (optional) opmode: The operation mode.
             %
             % Example:
-            % jointnames={'LBR4p_joint1','LBR4p_joint2','LBR4p_joint3','LBR4p_joint4',...
-            %             'LBR4p_joint5','LBR4p_joint6','LBR4p_joint7'};
-            %       u = [0.1 0.1 0.1 0.1 0.1 0.1 0.1];
-            %       set_joint_target_velocities(jointnames, u);
+            %      jointnames={'LBR4p_joint1','LBR4p_joint2','LBR4p_joint3','LBR4p_joint4',...
+            %                  'LBR4p_joint5','LBR4p_joint6','LBR4p_joint7'};
+            %      u = [0.1 0.1 0.1 0.1 0.1 0.1 0.1];
+            %      set_joint_target_velocities(jointnames, u);
             
             if nargin == 3
                 % The recommended mode is OP_ONESHOT
@@ -629,9 +783,7 @@ classdef DQ_VrepInterface < handle
                         opmode);
                 end                
             end            
-        end     
-
-        
+        end         
     end
     
 end


### PR DESCRIPTION
# Main instructions

By submitting this pull request, you automatically agree that you have read and accepted the following conditions:

- Anyone wanting to propose a new modification or introduce new functionality should reach out to the team first, as proposed modifications that do not comply with the library's development philosophy and style, do not follow the library's architecture, do not introduce a clear and general benefit to the library other than to the person who proposed the modification will likely be rejected with no further discussion.
- Support for DQ Robotics is given voluntarily and it is not the developers' role to educate and/or convince anyone of their vision.
- Any possible response and its timeliness will be based on the relevance, accuracy, and politeness of a request and the following discussion.
- You are familiar with the [development workflow](https://github.com/dqrobotics/matlab/blob/master/CONTRIBUTING.md).
- Each pull request should contain only individual changes (several changes of the same type **are allowed** on the same pull request).
- Refactoring or modifying internal implementation that is working is not allowed unless comprehensively discussed with and approved by @bvadorno and @mmmarinho.


## Description of changes

![](https://img.shields.io/badge/Tested%20on%20-CoppeliaSim%204.5.1-green) ![](https://img.shields.io/badge/Tested%20on-Windows%2011%2064bits-blue)

Hi @bvadorno and @mmmarinho,
This PR adds/improves the documentation of the class `DQ_VrepInterface.m`. 

List of changes:
- All public methods have their respective documentation following the DQ Robotic's standards. 
- I modified the name of some arguments of some methods to provide a more descriptive name. Furthermore, aiming the minimal internal modifications, I added some aliases inside some methods. For instance:

Current:
```matlab
function set_joint_positions(obj,handles,thetas,opmode)
            %% Set the joint positions of a robot in V-REP. For joints that are in 'Passive Mode' in V-REP
            %%  >> joint_names = {'redundantRob_joint1','redundantRob_joint2','redundantRob_joint3','redundantRob_joint4','redundantRob_joint5','redundantRob_joint6','redundantRob_joint7'};
            %%  >> vi.set_joint_positions(joint_names,[0 pi/2 0 pi/2 0 pi/2 0]);
            
            .
            .
            .
end
```
Proposal:
```matlab
function set_joint_positions(obj,jointnames,joint_positions,opmode)
            % This method sets the joint positions of a robot in the server.
            % It is required a dynamics disabled scene. 
            %
            % Usage:
            %      set_joint_positions(jointnames, joint_positions, opmode)   
            %          jointnames: The joint names.
            %          joint_positions: The joint positions.
            %          (optional) opmode: The operation mode.
            %
            % Example:
            %      jointnames={'LBR4p_joint1','LBR4p_joint2','LBR4p_joint3','LBR4p_joint4',...
            %                  'LBR4p_joint5','LBR4p_joint6','LBR4p_joint7'};
            %       u = [0.1 0.1 0.1 0.1 0.1 0.1 0.1];
            %       set_joint_positions(jointnames, u);
            handles = jointnames;
            thetas = joint_positions;
            
            .
            .
            .          
            
end
```


## Rationale

This PR was previously discussed [here](https://github.com/dqrobotics/matlab/pull/97#issuecomment-1538221628])

Please let me know if additional modifications are required.

Best regards,

Juancho