### PR TITLE
This PR adds a static method to compute the line-to-line-angle-residual

### DIFF
--- a/robot_modeling/DQ_Kinematics.m
+++ b/robot_modeling/DQ_Kinematics.m
@@ -357,7 +357,7 @@ classdef DQ_Kinematics < handle
         % 
         % As f(d) is a continuous bijective function, controlling f(d) is
         % equivalent to controlling the angle between the lines.
-        
+        %
         %
         % For more details, see Eq. (10) of Juan José Quiroz-Omaña, and
         % Bruno Vilhena Adorno (2019). Whole-Body Control with (Self) Collision

--- a/robot_modeling/DQ_Kinematics.m
+++ b/robot_modeling/DQ_Kinematics.m
@@ -404,7 +404,7 @@ classdef DQ_Kinematics < handle
         % to the line collinear with, respectively, the x-axis, y-axis, and 
         % z-axis of 'x'.
         %
-        % For more details see Eq. 20 of?Marinho, M. M., Adorno, B. V., 
+        % For more details see Eq. 20 of Marinho, M. M., Adorno, B. V., 
         % Harada, K., & Mitsuishi, M. "Active Constraints Using Vector
         % Field Inequalities for Surgical Robots." ICRA 2018.
         % https://doi.org/10.1109/ICRA.2018.8461105

--- a/robot_modeling/DQ_Kinematics.m
+++ b/robot_modeling/DQ_Kinematics.m
@@ -371,12 +371,12 @@ classdef DQ_Kinematics < handle
         end
 
 
-        function residual = line_to_line_angle_residual(robot_line, ...
-                 workspace_line, workspace_line_derivative) 
-        % LINE_TO_LINE_ANGLE_RESIDUAL(robot_point, workspace_line,
-        % workspace_line_derivative) returns the residual related to the
-        % moving line orientation in the workspace that is independent of 
-        % the robot motion (i.e., which does not depend on the robot joint
+        function residual = line_to_line_angle_residual(robot_line_direction, ...
+                 workspace_line_direction, workspace_line_direction_derivative) 
+        % LINE_TO_LINE_ANGLE_RESIDUAL(robot_line_direction,  workspace_line_direction,
+        % workspace_line_direction_derivative) returns the residual related 
+        % to the moving line orientation in the workspace that is independent 
+        % of the robot motion (i.e., which does not depend on the robot joint
         % velocities). 
         %
         % For more details see Eq. 4.30 of Juan José Quiroz-Omaña."Whole-Body 
@@ -385,12 +385,20 @@ classdef DQ_Kinematics < handle
         % Minas Gerais, 2021.
         % https://repositorio.ufmg.br/handle/1843/38700
 
-                if ~is_line(robot_line) || ~is_line(workspace_line)
-                    error(['robot_line and'...
-                           'workspace_line must be lines.']);
+                if ~is_line(robot_line_direction) ...
+                    || ~is_quaternion(robot_line_direction) 
+                    error('robot_line_direction must be a unit pure quaternion.');
                 end
-                residual = 2*dot(robot_line-workspace_line,...
-                            -1.0*workspace_line_derivative);
+                if ~is_line(workspace_line_direction) ||...
+                    ~is_quaternion(workspace_line_direction) 
+                    error('workspace_line_direction must be a unit pure quaternion.');
+                end
+                if ~is_pure(workspace_line_direction_derivative) ...
+                    || ~is_quaternion(workspace_line_direction_derivative) 
+                    error('workspace_line_direction_derivative must be a pure quaternion.');
+                end
+                residual = 2*dot(robot_line_direction - workspace_line_direction,...
+                                    -workspace_line_direction_derivative);
         end
    
         

--- a/robot_modeling/DQ_Kinematics.m
+++ b/robot_modeling/DQ_Kinematics.m
@@ -23,6 +23,7 @@
 %       line_to_point_distance_jacobian - Compute the line-to-line distance Jacobian.
 %       line_to_point_residual - Compute the line-to-point residual.
 %       line_to_line_angle_jacobian - Compute the line-to-line angle Jacobian.
+%       line_to_line_angle_residual - Compute the line-to-line angle residual.
 %       plane_jacobian - Compute the plane Jacobian.
 %       plane_to_point_distance_jacobian - Compute the plane-to-point distance Jacobian.
 %       plane_to_point_residual - Compute the plane-to-point residual.
@@ -61,6 +62,7 @@
 %
 %     2. Juan Jose Quiroz Omana (juanjqo@g.ecc.u-tokyo.ac.jp)
 %        - Added the property dim_configuration_space. 
+%        - Added the method line_to_line_angle_residual().
 
 classdef DQ_Kinematics < handle
     % DQ_Kinematics inherits the HANDLE superclass to avoid unnecessary copies
@@ -366,6 +368,29 @@ classdef DQ_Kinematics < handle
             Jl = line_jacobian(1:4, 1:n_columns);
             J = 2*vec4(robot_line - workspace_line)'*Jl;
             
+        end
+
+
+        function residual = line_to_line_angle_residual(robot_line, ...
+                 workspace_line, workspace_line_derivative) 
+        % LINE_TO_LINE_ANGLE_RESIDUAL(robot_point, workspace_line,
+        % workspace_line_derivative) returns the residual related to the
+        % moving line orientation in the workspace that is independent of 
+        % the robot motion (i.e., which does not depend on the robot joint
+        % velocities). 
+        %
+        % For more details see Eq. 4.30 of Juan José Quiroz-Omaña."Whole-Body 
+        % Control of Humanoids Robots at Second Order Kinematics Under 
+        % Unilateral Constraints." PhD thesis, Federal University of
+        % Minas Gerais, 2021.
+        % https://repositorio.ufmg.br/handle/1843/38700
+
+                if ~is_line(robot_line) || ~is_line(workspace_line)
+                    error(['robot_line and'...
+                           'workspace_line must be lines.']);
+                end
+                residual = 2*dot(robot_line-workspace_line,...
+                            -1.0*workspace_line_derivative);
         end
    
         


### PR DESCRIPTION
# Main instructions

By submitting this pull request, you automatically agree that you have read and accepted the following conditions:

- Anyone wanting to propose a new modification or introduce new functionality should reach out to the team first, as proposed modifications that do not comply with the library's development philosophy and style, do not follow the library's architecture, do not introduce a clear and general benefit to the library other than to the person who proposed the modification will likely be rejected with no further discussion.
- Support for DQ Robotics is given voluntarily and it is not the developers' role to educate and/or convince anyone of their vision.
- Any possible response and its timeliness will be based on the relevance, accuracy, and politeness of a request and the following discussion.
- You are familiar with the [development workflow](https://github.com/dqrobotics/matlab/blob/master/CONTRIBUTING.md).
- Each pull request should contain only individual changes (several changes of the same type **are allowed** on the same pull request).
- Refactoring or modifying internal implementation that is working is not allowed unless comprehensively discussed with and approved by @bvadorno and @mmmarinho.


## Description of changes

@dqrobotics/developers 

Hi @bvadorno,

this PR adds the method `line_to_line_angle_residual()`.  In addition, I fixed two minimal typos in the documentation.

## Rationale

The method is available in Python/C++ but is missing in the Matlab version. This PR is one of the to-do tasks defined [here](https://github.com/dqrobotics/developers-playground/discussions/1#discussion-5173754).
