### PR TITLE
This PR implements the protected methods check_ith_link(ith_link) and  check_q_vec(q_vec)

### DIFF
--- a/robot_modeling/DQ_Kinematics.m
+++ b/robot_modeling/DQ_Kinematics.m
@@ -135,18 +135,6 @@ classdef DQ_Kinematics < handle
     end
 
     methods (Access = protected)
-        function check_ith_link(obj, ith_link)
-            % This method throws an exception if the index to a link is invalid. 
-            % Usage:
-            %       check_ith_link(ith_link)
-            %
-            %          ith_link: The index to a link.
-
-            if(ith_link > obj.get_dim_configuration_space() || ith_link < 0)            
-                error("Tried to access link index " + string(ith_link) + ...
-                      " which is unnavailable.");
-            end
-        end
 
         function check_q_vec(obj, q_vec)
             % This method throws an exception if the size of the vector 'q' is 

--- a/robot_modeling/DQ_Kinematics.m
+++ b/robot_modeling/DQ_Kinematics.m
@@ -63,6 +63,7 @@
 %     2. Juan Jose Quiroz Omana (juanjqo@g.ecc.u-tokyo.ac.jp)
 %        - Added the property dim_configuration_space. 
 %        - Added the method line_to_line_angle_residual().
+%        - Added the methods check_ith_link() and check_q_vec().
 
 classdef DQ_Kinematics < handle
     % DQ_Kinematics inherits the HANDLE superclass to avoid unnecessary copies
@@ -131,6 +132,35 @@ classdef DQ_Kinematics < handle
         end
         
       
+    end
+
+    methods (Access = protected)
+        function check_ith_link(obj, ith_link)
+            % This method throws an exception if the index to a link is invalid. 
+            % Usage:
+            %       check_ith_link(ith_link)
+            %
+            %          ith_link: The index to a link.
+
+            if(ith_link > obj.get_dim_configuration_space() || ith_link < 0)            
+                error("Tried to access link index " + string(ith_link) + ...
+                      " which is unnavailable.");
+            end
+        end
+
+        function check_q_vec(obj, q_vec)
+            % This method throws an exception if the size of the vector 'q' is 
+            % different from the dimension of the configuration space.
+            % Usage:
+            %       check_q_vec(q_vec)
+            %
+            %          q_vec: Vector of joint values.
+
+            if(length(q_vec) ~= obj.get_dim_configuration_space())
+              error("Input vector must have size " + ...
+                    string(obj.get_dim_configuration_space()));
+            end
+        end
     end
     
     methods (Abstract)

--- a/robot_modeling/DQ_SerialManipulator.m
+++ b/robot_modeling/DQ_SerialManipulator.m
@@ -185,7 +185,9 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
             %   into account that transformation, use FKM(q)
             %   instead.
             
+            obj.check_q_vec(q);
             if nargin == 3
+                obj.check_ith_link(ith);
                 x = obj.reference_frame*obj.raw_fkm(q, ith); %Takes into account the base displacement
             else
                 x = obj.reference_frame*obj.raw_fkm(q)*obj.effector;
@@ -317,7 +319,12 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
             % q is the vector of joint variables. It takes into account
             % both base and end-effector displacements (their default
             % values are 1).
-            
+
+            obj.check_q_vec(q);
+            if nargin == 3
+                obj.check_ith_link(ith);
+            end
+
             if nargin == 3 && ith < obj.get_dim_configuration_space()
                 % If the Jacobian is not related to the mapping between the
                 % end-effector velocities and the joint velocities, it takes
@@ -341,6 +348,12 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
             % ith columns of the Jacobian time derivative.
             % This function does not take into account any base or
             % end-effector displacements.
+
+            obj.check_q_vec(q);
+            obj.check_q_vec(q_dot);
+            if nargin == 4
+                obj.check_ith_link(ith);
+            end
             
             if nargin == 4 && ith < obj.get_dim_configuration_space()
                 % If the Jacobian derivative is not related to the mapping between the

--- a/robot_modeling/DQ_SerialManipulator.m
+++ b/robot_modeling/DQ_SerialManipulator.m
@@ -120,6 +120,19 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
                   end
             end
          end
+
+         function check_ith_link(obj, ith_link)
+            % This method throws an exception if the index to a link is invalid. 
+            % Usage:
+            %       check_ith_link(ith_link)
+            %
+            %          ith_link: The index to a link.
+
+            if(ith_link > obj.get_dim_configuration_space() || ith_link < 0)            
+                error("Tried to access link index " + string(ith_link) + ...
+                      " which is unnavailable.");
+            end
+        end
      end 
 
     methods


### PR DESCRIPTION
# Main instructions

By submitting this pull request, you automatically agree that you have read and accepted the following conditions:

- Anyone wanting to propose a new modification or introduce new functionality should reach out to the team first, as proposed modifications that do not comply with the library's development philosophy and style, do not follow the library's architecture, do not introduce a clear and general benefit to the library other than to the person who proposed the modification will likely be rejected with no further discussion.
- Support for DQ Robotics is given voluntarily and it is not the developers' role to educate and/or convince anyone of their vision.
- Any possible response and its timeliness will be based on the relevance, accuracy, and politeness of a request and the following discussion.
- You are familiar with the [development workflow](https://github.com/dqrobotics/matlab/blob/master/CONTRIBUTING.md).
- Each pull request should contain only individual changes (several changes of the same type **are allowed** on the same pull request).
- Refactoring or modifying internal implementation that is working is not allowed unless comprehensively discussed with and approved by @bvadorno and @mmmarinho.

## Description of changes
![Static Badge](https://img.shields.io/badge/PR_type%3A-Pending%20tasks%20for%20the%2023.04%20release-blue)

![PR](https://github.com/dqrobotics/matlab/assets/23158313/21ff4789-6d55-45ec-b8c7-7e9aa5b1007a)
@dqrobotics/developers 

Hi @bvadorno, this PR implements the protected methods `check_ith_link(ith_link)` and  `check_q_vec(q_vec)`.  Furthermore, the methods `DQ_SerialManipulator.fkm()`, `DQ_SerialManipulator.pose_jacobian()`, and `DQ_SerialManipulator.pose_jacobian_derivative()` are updated to test if both the index and the dimension of the vector joints are valid. The rationale behind this is twofold:

1. Test the new methods `check_ith_link(ith_link)` and  `check_q_vec(q_vec)`. 
2. Fix an unexpected behavior in the `DQ_SerialManipulator` class

Example (of the unexpected behavior):

Consider this minimal example with a 7-DOF serial manipulator, in which the user tries to compute the pose Jacobian derivative to the joint 9 (An invalid joint, therefore I would expect an exception). 

```matlab
clear all
close all
clc

robot = FrankaEmikaPandaRobot.kinematics();
q = zeros(7,1);
J = robot.pose_jacobian(q,9);  % The index 9 is no valid!
disp('OK')
```

Output (Current Master Branch):
```matlab
OK
>> 
```


Output (Proposed Modifications):
```shell
Error using DQ_Kinematics/check_ith_link
Tried to access link index 9 which is unnavailable.

Error in DQ_SerialManipulator/pose_jacobian (line 325)
                obj.check_ith_link(ith);
>> 
```


Best regards, 

Juancho





