### PR TITLE
This PR implements setter and getters methods for DH parameters in classes DQ_SerialManipulatorDH and MDH.

### DIFF
--- a/robot_modeling/DQ_ParameterDH.m
+++ b/robot_modeling/DQ_ParameterDH.m
@@ -1,0 +1,32 @@
+% (C) Copyright 2023 DQ Robotics Developers
+%
+% This file is part of DQ Robotics.
+%
+%     DQ Robotics is free software: you can redistribute it and/or modify
+%     it under the terms of the GNU Lesser General Public License as published
+%     by the Free Software Foundation, either version 3 of the License, or
+%     (at your option) any later version.
+%
+%     DQ Robotics is distributed in the hope that it will be useful,
+%     but WITHOUT ANY WARRANTY; without even the implied warranty of
+%     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%     GNU Lesser General Public License for more details.
+%
+%     You should have received a copy of the GNU Lesser General Public License
+%     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
+%
+% DQ Robotics website: dqrobotics.github.io
+%
+% Contributors to this file:
+%
+%   1. Juan Jose Quiroz Omana (juanjqo@g.ecc.u-tokyo.ac.jp) 
+%      Responsible for the original implementation.
+
+classdef DQ_ParameterDH
+   enumeration
+      THETA    
+      D        
+      A        
+      ALPHA    
+   end
+end

--- a/robot_modeling/DQ_SerialManipulator.m
+++ b/robot_modeling/DQ_SerialManipulator.m
@@ -822,7 +822,8 @@ function o = plot_options(robot, optin)
             % TODO
             % This part of the code assumes we are using the 
             %  DH parametrization. We need to fix it in future versions.
-            reach = reach + abs(robot.a(i)) + abs(robot.d(i));
+            reach = reach + abs(robot.get_parameter("A",i)) + ...
+                            abs(robot.get_parameter("D",i)); 
         end
         o.workspace = [-reach reach -reach reach -reach reach];      
     else

--- a/robot_modeling/DQ_SerialManipulatorDH.m
+++ b/robot_modeling/DQ_SerialManipulatorDH.m
@@ -69,7 +69,7 @@
 %          to define DQ_SerialManipulator as an abstract class.           
 
 classdef DQ_SerialManipulatorDH < DQ_SerialManipulator
-    properties
+    properties (Access = protected)
         theta,d,a,alpha;
     end
     

--- a/robot_modeling/DQ_SerialManipulatorDH.m
+++ b/robot_modeling/DQ_SerialManipulatorDH.m
@@ -238,13 +238,13 @@ classdef DQ_SerialManipulatorDH < DQ_SerialManipulator
             end
 
             switch parameterType
-                case DQ_DHParameter.THETA
+                case DQ_ParameterDH.THETA
                     ret = obj.theta(ith_joint);
-                case DQ_DHParameter.D
+                case DQ_ParameterDH.D
                     ret = obj.d(ith_joint);
-                case DQ_DHParameter.A
+                case DQ_ParameterDH.A
                     ret = obj.a(ith_joint);
-                case DQ_DHParameter.ALPHA
+                case DQ_ParameterDH.ALPHA
                     ret = obj.alpha(ith_joint);                    
             end 
         end

--- a/robot_modeling/DQ_SerialManipulatorDH.m
+++ b/robot_modeling/DQ_SerialManipulatorDH.m
@@ -195,7 +195,108 @@ classdef DQ_SerialManipulatorDH < DQ_SerialManipulator
             obj.alpha = A(4,:);
             obj.set_joint_types(A(5,:));
         end
-        
+
+        function ret = get_parameters(obj, parameterType)
+            % This method returns a vector containing the DH parameters.
+            % Usage: get_dh_parameters(parameterType)
+            %           parameterType: Parameter type, which corresponds to
+            %                          "THETA", "D", "A", or "ALPHA".
+            arguments
+               obj
+               parameterType DQ_ParameterDH              
+            end
+
+            switch parameterType
+                case DQ_ParameterDH.THETA
+                    ret = obj.theta;
+                case DQ_ParameterDH.D
+                    ret = obj.d;
+                case DQ_ParameterDH.A
+                    ret = obj.a;
+                case DQ_ParameterDH.ALPHA
+                    ret = obj.alpha;                    
+            end            
+        end
+
+        function ret = get_parameter(obj, parameterType, ith_joint)
+            % This method returns the DH parameter of the ith joint.
+            % Usage: get_parameter(parameterType, ith_joint)
+            %           parameterType: Parameter type, which corresponds to
+            %                          "THETA", "D", "A", or "ALPHA".
+            %           ith_joint: Joint number.
+            arguments
+               obj
+               parameterType DQ_ParameterDH 
+               ith_joint int32
+            end
+
+            switch parameterType
+                case DQ_DHParameter.THETA
+                    ret = obj.theta(ith_joint);
+                case DQ_DHParameter.D
+                    ret = obj.d(ith_joint);
+                case DQ_DHParameter.A
+                    ret = obj.a(ith_joint);
+                case DQ_DHParameter.ALPHA
+                    ret = obj.alpha(ith_joint);                    
+            end 
+        end
+
+        function set_parameters(obj, parameterType, vector_parameters)
+            % This method sets the DH parameters.
+            % Usage: set_parameters(parameterType, vector_parameters)
+            %           parameterType: Parameter type, which corresponds to
+            %                          "THETA", "D", "A", or "ALPHA".
+            %           vector_parameters: Vector containing the new
+            %                              parameters.
+            arguments
+               obj
+               parameterType DQ_ParameterDH   
+               vector_parameters double
+            end
+
+            obj.check_q_vec(vector_parameters);
+            vector_parameters = reshape(vector_parameters, [1, obj.get_dim_configuration_space()]);
+
+            switch parameterType
+                case DQ_ParameterDH.THETA
+                    obj.theta    =  vector_parameters;
+                case DQ_ParameterDH.D
+                    obj.d        =  vector_parameters;
+                case DQ_ParameterDH.A
+                    obj.a        =  vector_parameters;
+                case DQ_ParameterDH.ALPHA
+                    obj.alpha    =  vector_parameters;                  
+            end 
+        end
+
+        function set_parameter(obj, parameterType, ith_joint, parameter)
+            % This method sets the DH parameter of the ith joint.
+            % Usage: set_parameters(parameterType, vector_parameters)
+            %           parameterType: Parameter type, which corresponds to
+            %                          "THETA", "D", "A", or "ALPHA".
+            %           ith_joint: Joint number.
+            %           parameter: The new parameter.
+            arguments
+               obj
+               parameterType DQ_ParameterDH 
+               ith_joint int32
+               parameter double
+            end
+
+            obj.check_ith_link(ith_joint);
+
+            switch parameterType
+                case DQ_ParameterDH.THETA
+                    obj.theta(ith_joint) =  parameter;
+                case DQ_ParameterDH.D
+                    obj.d(ith_joint)     =  parameter;
+                case DQ_ParameterDH.A
+                    obj.a(ith_joint)     =  parameter;
+                case DQ_ParameterDH.ALPHA
+                    obj.alpha(ith_joint) =  parameter;                  
+            end 
+        end
     
         
     end

--- a/robot_modeling/DQ_SerialManipulatorDH.m
+++ b/robot_modeling/DQ_SerialManipulatorDH.m
@@ -205,7 +205,7 @@ classdef DQ_SerialManipulatorDH < DQ_SerialManipulator
 
         function ret = get_parameters(obj, parameterType)
             % This method returns a vector containing the DH parameters.
-            % Usage: get_dh_parameters(parameterType)
+            % Usage: get_parameters(parameterType)
             %           parameterType: Parameter type, which corresponds to
             %                          "THETA", "D", "A", or "ALPHA".
             arguments

--- a/robot_modeling/DQ_SerialManipulatorDH.m
+++ b/robot_modeling/DQ_SerialManipulatorDH.m
@@ -28,6 +28,10 @@
 %       raw_pose_jacobian - Compute the pose Jacobian without taking into account base's and end-effector's rigid transformations.
 %       raw_pose_jacobian_derivative - Compute the pose Jacobian derivative without taking into account base's and end-effector's rigid transformations.
 %       set_effector - Set an arbitrary end-effector rigid transformation with respect to the last frame in the kinematic chain.
+%       get_parameters - Return a vector containing the DH parameters.
+%       get_parameter -  Return the DH parameter of the ith joint.
+%       set_parameters - Set the DH parameters.
+%       set_parameter -  Set the DH parameter of the ith joint.
 % See also DQ_SerialManipulator.
 
 % (C) Copyright 2020-2023 DQ Robotics Developers
@@ -66,7 +70,10 @@
 %
 %     3. Juan Jose Quiroz Omana (juanjqo@g.ecc.u-tokyo.ac.jp)
 %        - Added some modifications discussed at #75 (https://github.com/dqrobotics/matlab/pull/75)
-%          to define DQ_SerialManipulator as an abstract class.           
+%          to define DQ_SerialManipulator as an abstract class.   
+%
+%        - Added the following methods: get_parameter, get_parameters,
+%          set_parameter, and set_parameters.
 
 classdef DQ_SerialManipulatorDH < DQ_SerialManipulator
     properties (Access = protected)

--- a/robot_modeling/DQ_SerialManipulatorMDH.m
+++ b/robot_modeling/DQ_SerialManipulatorMDH.m
@@ -28,6 +28,10 @@
 %       raw_pose_jacobian - Compute the pose Jacobian without taking into account base's and end-effector's rigid transformations.
 %       raw_pose_jacobian_derivative - Compute the pose Jacobian derivative without taking into account base's and end-effector's rigid transformations.
 %       set_effector - Set an arbitrary end-effector rigid transformation with respect to the last frame in the kinematic chain.
+%       get_parameters - Return a vector containing the DH parameters.
+%       get_parameter -  Return the DH parameter of the ith joint.
+%       set_parameters - Set the DH parameters.
+%       set_parameter -  Set the DH parameter of the ith joint.
 % See also DQ_SerialManipulator.
 
 % (C) Copyright 2020-2023 DQ Robotics Developers
@@ -64,13 +68,16 @@
 %     3. Juan Jose Quiroz Omana (juanjqo@g.ecc.u-tokyo.ac.jp)
 %        - Created this file. Implemented the case for prismatic joints
 %          in method get_w().
+%
+%        - Added the following methods: get_parameter, get_parameters,
+%          set_parameter, and set_parameters.
 
 
 
 
 
 classdef DQ_SerialManipulatorMDH < DQ_SerialManipulator
-    properties
+    properties (Access = protected)
         theta,d,a,alpha;
     end
     
@@ -189,6 +196,108 @@ classdef DQ_SerialManipulatorMDH < DQ_SerialManipulator
             obj.a     = A(3,:);
             obj.alpha = A(4,:);
             obj.set_joint_types(A(5,:));
+        end
+
+        function ret = get_parameters(obj, parameterType)
+            % This method returns a vector containing the DH parameters.
+            % Usage: get_parameters(parameterType)
+            %           parameterType: Parameter type, which corresponds to
+            %                          "THETA", "D", "A", or "ALPHA".
+            arguments
+               obj
+               parameterType DQ_ParameterDH              
+            end
+
+            switch parameterType
+                case DQ_ParameterDH.THETA
+                    ret = obj.theta;
+                case DQ_ParameterDH.D
+                    ret = obj.d;
+                case DQ_ParameterDH.A
+                    ret = obj.a;
+                case DQ_ParameterDH.ALPHA
+                    ret = obj.alpha;                    
+            end            
+        end
+
+        function ret = get_parameter(obj, parameterType, ith_joint)
+            % This method returns the DH parameter of the ith joint.
+            % Usage: get_parameter(parameterType, ith_joint)
+            %           parameterType: Parameter type, which corresponds to
+            %                          "THETA", "D", "A", or "ALPHA".
+            %           ith_joint: Joint number.
+            arguments
+               obj
+               parameterType DQ_ParameterDH 
+               ith_joint int32
+            end
+
+            switch parameterType
+                case DQ_ParameterDH.THETA
+                    ret = obj.theta(ith_joint);
+                case DQ_ParameterDH.D
+                    ret = obj.d(ith_joint);
+                case DQ_ParameterDH.A
+                    ret = obj.a(ith_joint);
+                case DQ_ParameterDH.ALPHA
+                    ret = obj.alpha(ith_joint);                    
+            end 
+        end
+
+        function set_parameters(obj, parameterType, vector_parameters)
+            % This method sets the DH parameters.
+            % Usage: set_parameters(parameterType, vector_parameters)
+            %           parameterType: Parameter type, which corresponds to
+            %                          "THETA", "D", "A", or "ALPHA".
+            %           vector_parameters: Vector containing the new
+            %                              parameters.
+            arguments
+               obj
+               parameterType DQ_ParameterDH   
+               vector_parameters double
+            end
+
+            obj.check_q_vec(vector_parameters);
+            vector_parameters = reshape(vector_parameters, [1, obj.get_dim_configuration_space()]);
+
+            switch parameterType
+                case DQ_ParameterDH.THETA
+                    obj.theta    =  vector_parameters;
+                case DQ_ParameterDH.D
+                    obj.d        =  vector_parameters;
+                case DQ_ParameterDH.A
+                    obj.a        =  vector_parameters;
+                case DQ_ParameterDH.ALPHA
+                    obj.alpha    =  vector_parameters;                  
+            end 
+        end
+
+        function set_parameter(obj, parameterType, ith_joint, parameter)
+            % This method sets the DH parameter of the ith joint.
+            % Usage: set_parameters(parameterType, vector_parameters)
+            %           parameterType: Parameter type, which corresponds to
+            %                          "THETA", "D", "A", or "ALPHA".
+            %           ith_joint: Joint number.
+            %           parameter: The new parameter.
+            arguments
+               obj
+               parameterType DQ_ParameterDH 
+               ith_joint int32
+               parameter double
+            end
+
+            obj.check_ith_link(ith_joint);
+
+            switch parameterType
+                case DQ_ParameterDH.THETA
+                    obj.theta(ith_joint) =  parameter;
+                case DQ_ParameterDH.D
+                    obj.d(ith_joint)     =  parameter;
+                case DQ_ParameterDH.A
+                    obj.a(ith_joint)     =  parameter;
+                case DQ_ParameterDH.ALPHA
+                    obj.alpha(ith_joint) =  parameter;                  
+            end 
         end
         
     end


### PR DESCRIPTION
# Main instructions

By submitting this pull request, you automatically agree that you have read and accepted the following conditions:

- Anyone wanting to propose a new modification or introduce new functionality should reach out to the team first, as proposed modifications that do not comply with the library's development philosophy and style, do not follow the library's architecture, do not introduce a clear and general benefit to the library other than to the person who proposed the modification will likely be rejected with no further discussion.
- Support for DQ Robotics is given voluntarily, and it is not the developers' role to educate and/or convince anyone of their vision.
- Any possible response and its timeliness will be based on the relevance, accuracy, and politeness of a request and the following discussion.
- You are familiar with the [development workflow](https://github.com/dqrobotics/matlab/blob/master/CONTRIBUTING.md).
- Each pull request should contain only individual changes (several changes of the same type **are allowed** on the same pull request).
- Refactoring or modifying an internal implementation that is working is not allowed unless comprehensively discussed with and approved by @bvadorno and @mmmarinho.

![](https://img.shields.io/badge/type-pending_tasks_for_the_23.04_release-blue)


## Description of changes

@dqrobotics/developers 

Hi @bvadorno,

This PR implements setter and getters methods for DH parameters in classes DQ_SerialManipulatorDH and MDH. This feature was previously discussed and approved in [Pending tasks for the 23.04 release](https://github.com/dqrobotics/developers-playground/discussions/1)

### List of modifications

  - The properties `theta`, `d`, `a`, `alpha` in classes `DQ_SerialManipulatorDH()` and `DQ_SerialManipulatorMDH()` are now protected.
  ```matlab
      properties (Access = protected)
        theta,d,a,alpha;
      end
  ```
  
  - A new enum class was added: `DQ_ParameterDH`
  ```matlab
  classdef DQ_ParameterDH
         enumeration
                  THETA    
                  D        
                  A        
                  ALPHA    
         end
end
  ```

- New public methods to set and get the parameters:
  - `get_parameters(parameterType)`
  - `get_parameter (parameterType, ith_joint)`
  - `set_parameter (parameterType, ith_joint, parameter)`
  - `set_parameters(parameterType, ith_joint, vector_parameters)`
  
  ### How to use
  

  ```matlab
  robot = FrankaEmikaPandaRobot.kinematics();
  robot.get_parameters("THETA") ; %  or  robot.get_parameters(DQ_ParameterDH.THETA)
  robot.set_parameters("THETA", [1 1 1 1 1 1 1])
  robot.get_parameter ("THETA", 2) ; 
  robot.set_parameter ("THETA", 2, 0.01)
  
  robot.get_parameters(DQ_ParameterDH.ALPHA)
  robot.set_parameter (DQ_ParameterDH.ALPHA, 2, 0.01)
  ```

### Unitary test

I implemented a test to check the new methods in both classes `DQ_SerialManipulatorDH()` and `DQ_SerialManipulatorMDH()`. (maybe this test could be added in matlab-tests?)

```matlab
    clear all
    close all
    clc
    
    format bank;
    
    robots = {FrankaEmikaPandaRobot.kinematics();
              ComauSmartSixRobot.kinematics();
              KukaLwr4Robot.kinematics()};
    
    for i=1:length(robots)
        test_parameters(robots{i});
        test_parameter(robots{i});
    end
    
    function test_parameter(robot)
    
        parameters = [DQ_ParameterDH.THETA; 
                      DQ_ParameterDH.D;
                      DQ_ParameterDH.A;
                      DQ_ParameterDH.ALPHA];
        
            new_value = randn;
            rnd_index = randi([1,robot.get_dim_configuration_space()]);
            
            for i=1:4
                robot.set_parameter(parameters(i), rnd_index,new_value)
            end
            
            
            TestCase = matlab.unittest.TestCase.forInteractiveUse;
            
            for i=1:4
                TestCase.assertEqual(robot.get_parameter(parameters(i),rnd_index),...
                                                         new_value,...
                "test_parameter test failed");
            end
    end
    
    
    function test_parameters(robot)
        n = robot.get_dim_configuration_space();
        
        parameters = [DQ_ParameterDH.THETA; 
                      DQ_ParameterDH.D;
                      DQ_ParameterDH.A;
                      DQ_ParameterDH.ALPHA];
        
        new_values = randn(4,n);
        
        for i=1:4
            robot.set_parameters(parameters(i), new_values(i,:))
        end
        
        TestCase = matlab.unittest.TestCase.forInteractiveUse;
        
        
        for i=1:4
            TestCase.assertEqual(robot.get_parameters(parameters(i)), ...
                                                     new_values(i,:),...
            "test_parameters failed");
        end
    
    end
```

```shell
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
Assertion passed.
>> 
```

Best regards, 

Juancho  
