### PR TITLE
This PR adds the class 'DQ_SerialVrepRobot'

### DIFF
--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -9,7 +9,7 @@
 %           >> vi.connect('127.0.0.1',19997);
 %           >> vrep_robot = DQ_SerialVrepRobot("my_robot", 7, "my_robot", vi);
 %           >> vi.start_simulation();
-%           >> vrep_robot.get_configuration_space_positions();
+%           >> vrep_robot.get_configuration();
 %           >> pause(1);
 %           >> vi.stop_simulation();
 %           >> vi.disconnect();

--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -134,7 +134,7 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
             %     q = zeros(7,1);
             %     vrep_robot.set_configuration_space_positions(q);
             %     
-            %     Note that this calls "set_joint_positions" in the remoteAPI, meaning that it
+            %     Note that this calls "set_joint_positions" in DQ_VrepInterface, meaning that it
             %     is only suitable for joints in kinematic mode.
 
             obj.vrep_interface.set_joint_positions(obj.joint_names, q)
@@ -157,7 +157,7 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
         function set_target_configuration_space_positions(obj, q_target)
             % This method sets the joint configurations of the robot in the CoppeliaSim scene as a target configuration for the joint controllers.
             % Usage:
-            %     set_target_configuration_space_positions(q);  
+            %     set_target_configuration_space_positions(q_target);  
             %          q_target: The target joint configurations of the robot in the CoppeliaSim scene.
             %
             % Example: 
@@ -167,7 +167,7 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
             %     q_target = zeros(7,1);
             %     vrep_robot.set_target_configuration_space_positions(q_target);
             %     
-            %     Note that this calls "set_joint_target_positions" in the remoteAPI, meaning that it
+            %     Note that this calls "set_joint_target_positions" in DQ_VrepInterface, meaning that it
             %     is only suitable for joints in dynamic mode with position control.
 
             obj.vrep_interface.set_joint_target_positions(obj.joint_names, q_target)
@@ -190,7 +190,7 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
         function set_target_configuration_space_velocities(obj, v_target)
             % This method sets the joint velocities of the robot in the CoppeliaSim scene as a target velocity for the joint controllers.
             % Usage:
-            %     set_target_configuration_space_positions(q);  
+            %     set_target_configuration_space_velocities(v_target);  
             %          v_target: The target joint velocities of the robot in the CoppeliaSim scene.
             %
             % Example: 
@@ -200,7 +200,7 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
             %     v_target = zeros(7,1);
             %     vrep_robot.set_target_configuration_space_velocities(v_target);
             %     
-            %     Note that this calls "set_joint_target_velocities" in the remoteAPI, meaning that it
+            %     Note that this calls "set_joint_target_velocities" in DQ_VrepInterface, meaning that it
             %     is only suitable for joints in dynamic mode with velocity control.
 
             obj.vrep_interface.set_joint_target_velocities(obj.joint_names, v_target);
@@ -209,7 +209,7 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
         function set_configuration_space_torques(obj,tau)
             % This method sets the joint torques of the robot in the CoppeliaSim scene.
             % Usage:
-            %     set_target_configuration_space_positions(q);  
+            %     set_configuration_space_torques(tau);  
             %          tau: The joint torques of the robot in the CoppeliaSim scene.
             %
             % Example: 
@@ -219,7 +219,7 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
             %     tau = zeros(7,1);
             %     vrep_robot.set_configuration_space_torques(tau);
             %     
-            %     Note that this calls "set_joint_torques" in the remoteAPI, meaning that it
+            %     Note that this calls "set_joint_torques" in DQ_VrepInterface, meaning that it
             %     is only suitable for joints in dynamic mode with force/torque control.
 
             obj.vrep_interface.set_joint_torques(obj.joint_names,tau)

--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -50,7 +50,9 @@
 %
 % Contributors to this file:
 %     1. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
-%        - Responsible for the original implementation.
+%        - Responsible for the original implementation, based on the C++ version:
+%           - DQ_VrepInterface.h: https://github.com/dqrobotics/cpp-interface-vrep/blob/master/include/dqrobotics/interfaces/vrep/DQ_VrepInterface.h
+%           - DQ_SerialVrepRobot.cpp: https://github.com/dqrobotics/cpp-interface-vrep/blob/master/src/dqrobotics/interfaces/vrep/DQ_SerialVrepRobot.cpp
 
 classdef DQ_SerialVrepRobot < DQ_VrepRobot
     properties

--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -21,7 +21,7 @@
 %       get_joint_names - Gets the joint names of the robot in the CoppeliaSim scene.
 %       set_configuration - Sets the joint configurations of the robot in the CoppeliaSim scene.
 %       get_configuration - Gets the joint configurations of the robot in the CoppeliaSim scene.
-%       set_target_configuration_space_positions - Sets the joint configurations of the robot in the CoppeliaSim scene as a target configuration for the joint controllers.
+%       set_target_configuration - Sets the joint configurations of the robot in the CoppeliaSim scene as a target configuration for the joint controllers.
 %       get_configuration_space_velocities - Gets the joint velocities of the robot in the CoppeliaSim scene.
 %       set_target_configuration_space_velocities - Sets the joint velocities of the robot in the CoppeliaSim scene as a target velocity for the joint controllers.
 %       set_configuration_space_torques - Sets the joint torques of the robot in the CoppeliaSim scene.

--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -119,10 +119,10 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
             joint_names = obj.joint_names;
         end
 
-        function set_configuration_space_positions(obj, q)
+        function set_configuration(obj, q)
             % This method sets the joint configurations of the robot in the CoppeliaSim scene.
             % Usage:
-            %     set_configuration_space_positions(q);  
+            %     set_configuration(q);  
             %          q: The joint configurations of the robot in the CoppeliaSim scene.
             %
             % Example: 
@@ -130,7 +130,7 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
             %     vi.connect('127.0.0.1',19997);
             %     vrep_robot = DQ_SerialVrepRobot("my_robot", 7, "my_robot#1", vi);
             %     q = zeros(7,1);
-            %     vrep_robot.set_configuration_space_positions(q);
+            %     vrep_robot.set_configuration(q);
             %     
             %     Note that this calls "set_joint_positions" in DQ_VrepInterface, meaning that it
             %     is only suitable for joints in kinematic mode.
@@ -138,24 +138,24 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
             obj.vrep_interface.set_joint_positions(obj.joint_names, q)
         end
         
-        function q = get_configuration_space_positions(obj)
+        function q = get_configuration(obj)
             % This method gets the joint configurations of the robot in the CoppeliaSim scene.
             % Usage:
-            %     get_configuration_space_positions;  
+            %     get_configuration;  
             %
             % Example: 
             %     vi = DQ_VrepInterface();
             %     vi.connect('127.0.0.1',19997);
             %     vrep_robot = DQ_SerialVrepRobot("my_robot", 7, "my_robot#1", vi);
-            %     q = vrep_robot.get_configuration_space_positions;
+            %     q = vrep_robot.get_configuration;
 
             q = obj.vrep_interface.get_joint_positions(obj.joint_names);
         end
 
-        function set_target_configuration_space_positions(obj, q_target)
+        function set_target_configuration(obj, q_target)
             % This method sets the joint configurations of the robot in the CoppeliaSim scene as a target configuration for the joint controllers.
             % Usage:
-            %     set_target_configuration_space_positions(q_target);  
+            %     set_target_configuration(q_target);  
             %          q_target: The target joint configurations of the robot in the CoppeliaSim scene.
             %
             % Example: 
@@ -163,7 +163,7 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
             %     vi.connect('127.0.0.1',19997);
             %     vrep_robot = DQ_SerialVrepRobot("my_robot", 7, "my_robot#1", vi);
             %     q_target = zeros(7,1);
-            %     vrep_robot.set_target_configuration_space_positions(q_target);
+            %     vrep_robot.set_target_configuration(q_target);
             %     
             %     Note that this calls "set_joint_target_positions" in DQ_VrepInterface, meaning that it
             %     is only suitable for joints in dynamic mode with position control.
@@ -171,24 +171,24 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
             obj.vrep_interface.set_joint_target_positions(obj.joint_names, q_target)
         end
         
-        function qd = get_configuration_space_velocities(obj)
+        function qd = get_configuration_velocities(obj)
             % This method gets the joint velocities of the robot in the CoppeliaSim scene.
             % Usage:
-            %     get_configuration_space_velocities;  
+            %     get_configuration_velocities;  
             %
             % Example: 
             %     vi = DQ_VrepInterface();
             %     vi.connect('127.0.0.1',19997);
             %     vrep_robot = DQ_SerialVrepRobot("my_robot", 7, "my_robot#1", vi);
-            %     qd = vrep_robot.get_configuration_space_velocities;
+            %     qd = vrep_robot.get_configuration_velocities;
             
             qd = obj.vrep_interface.get_joint_velocities(obj.joint_names);
         end
 
-        function set_target_configuration_space_velocities(obj, v_target)
+        function set_target_configuration_velocities(obj, v_target)
             % This method sets the joint velocities of the robot in the CoppeliaSim scene as a target velocity for the joint controllers.
             % Usage:
-            %     set_target_configuration_space_velocities(v_target);  
+            %     set_target_configuration_velocities(v_target);  
             %          v_target: The target joint velocities of the robot in the CoppeliaSim scene.
             %
             % Example: 
@@ -196,7 +196,7 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
             %     vi.connect('127.0.0.1',19997);
             %     vrep_robot = DQ_SerialVrepRobot("my_robot", 7, "my_robot#1", vi);
             %     v_target = zeros(7,1);
-            %     vrep_robot.set_target_configuration_space_velocities(v_target);
+            %     vrep_robot.set_target_configuration_velocities(v_target);
             %     
             %     Note that this calls "set_joint_target_velocities" in DQ_VrepInterface, meaning that it
             %     is only suitable for joints in dynamic mode with velocity control.

--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -22,7 +22,7 @@
 %       set_configuration - Sets the joint configurations of the robot in the CoppeliaSim scene.
 %       get_configuration - Gets the joint configurations of the robot in the CoppeliaSim scene.
 %       set_target_configuration - Sets the joint configurations of the robot in the CoppeliaSim scene as a target configuration for the joint controllers.
-%       get_configuration_space_velocities - Gets the joint velocities of the robot in the CoppeliaSim scene.
+%       get_configuration_velocities - Gets the joint velocities of the robot in the CoppeliaSim scene.
 %       set_target_configuration_space_velocities - Sets the joint velocities of the robot in the CoppeliaSim scene as a target velocity for the joint controllers.
 %       set_configuration_space_torques - Sets the joint torques of the robot in the CoppeliaSim scene.
 %       get_configuration_space_torques - Gets the joint torques of the robot in the CoppeliaSim scene.

--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -3,24 +3,31 @@
 %
 % Usage:
 %       1) Drag-and-drop a serial robot to a VREP scene. For instance, a
-%       "LBR4p" robot.
+%       "my_robot" robot.
 %       2) Run
 %           >> vi = DQ_VrepInterface();
 %           >> vi.connect('127.0.0.1',19997);
-%           >> vrep_robot = LBR4pVrepRobot("LBR4p", vi);
+%           >> vrep_robot = DQ_SerialVrepRobot("my_robot", 7, "my_robot", vi);
 %           >> vi.start_simulation();
-%           >> robot.get_q_from_vrep();
+%           >> vrep_robot.get_q_from_vrep();
 %           >> pause(1);
 %           >> vi.stop_simulation();
 %           >> vi.disconnect();
 %       Note that the name of the robot should be EXACTLY the same as in
 %       VREP. For instance, if you drag-and-drop a second robot, its name
-%       will become "LBR4p#0", a third robot, "LBR4p#1", and so on.
+%       will become "my_robot#0", a third robot, "my_robot#1", and so on.
 %
 %   DQ_SerialVrepRobot Methods:
-%       send_q_to_vrep - Sends the joint configurations to VREP
-%       get_q_from_vrep - Obtains the joint configurations from VREP
-%       kinematics - Obtains the DQ_Kinematics implementation of this robot
+%       get_joint_names - Gets the joint names of the robot in the CoppeliaSim scene.
+%       set_configuration_space_positions - Sets the joint configurations to the robot in the CoppeliaSim scene.
+%       get_configuration_space_positions - Gets the joint configurations of the robot in the CoppeliaSim scene.
+%       set_target_configuration_space_positions - Sets the joint configurations to the robot in the CoppeliaSim scene as a target configuration for the joint controllers.
+%       get_configuration_space_velocities - Gets the joint velocities of the robot in the CoppeliaSim scene.
+%       set_target_configuration_space_velocities - Sets the joint velocities of the robot in the CoppeliaSim scene as a target velocity for the joint controllers.
+%       set_configuration_space_torques - Sets the joint torques of the robot in the CoppeliaSim scene.
+%       get_configuration_space_torques - Gets the joint torques of the robot in the CoppeliaSim scene.
+%   DQ_SerialVrepRobot Methods (Protected):
+%       update_manipulator_dynamic_parameters - Updates the dynamic parameters of the serial robot in the CoppeliaSim scene
 
 % (C) Copyright 2018-2023 DQ Robotics Developers
 %

--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -9,7 +9,7 @@
 %           >> vi.connect('127.0.0.1',19997);
 %           >> vrep_robot = DQ_SerialVrepRobot("my_robot", 7, "my_robot", vi);
 %           >> vi.start_simulation();
-%           >> vrep_robot.get_q_from_vrep();
+%           >> vrep_robot.get_configuration_space_positions();
 %           >> pause(1);
 %           >> vi.stop_simulation();
 %           >> vi.disconnect();

--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -20,7 +20,7 @@
 %   DQ_SerialVrepRobot Methods:
 %       get_joint_names - Gets the joint names of the robot in the CoppeliaSim scene.
 %       set_configuration_space_positions - Sets the joint configurations of the robot in the CoppeliaSim scene.
-%       get_configuration_space_positions - Gets the joint configurations of the robot in the CoppeliaSim scene.
+%       get_configuration - Gets the joint configurations of the robot in the CoppeliaSim scene.
 %       set_target_configuration_space_positions - Sets the joint configurations of the robot in the CoppeliaSim scene as a target configuration for the joint controllers.
 %       get_configuration_space_velocities - Gets the joint velocities of the robot in the CoppeliaSim scene.
 %       set_target_configuration_space_velocities - Sets the joint velocities of the robot in the CoppeliaSim scene as a target velocity for the joint controllers.

--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -29,7 +29,7 @@
 %   DQ_SerialVrepRobot Methods (Protected):
 %       update_manipulator_dynamic_parameters - Updates the dynamic parameters of the serial robot in the CoppeliaSim scene
 
-% (C) Copyright 2018-2024 DQ Robotics Developers
+% (C) Copyright 2011-2024 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %

--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -19,9 +19,9 @@
 %
 %   DQ_SerialVrepRobot Methods:
 %       get_joint_names - Gets the joint names of the robot in the CoppeliaSim scene.
-%       set_configuration_space_positions - Sets the joint configurations to the robot in the CoppeliaSim scene.
+%       set_configuration_space_positions - Sets the joint configurations of the robot in the CoppeliaSim scene.
 %       get_configuration_space_positions - Gets the joint configurations of the robot in the CoppeliaSim scene.
-%       set_target_configuration_space_positions - Sets the joint configurations to the robot in the CoppeliaSim scene as a target configuration for the joint controllers.
+%       set_target_configuration_space_positions - Sets the joint configurations of the robot in the CoppeliaSim scene as a target configuration for the joint controllers.
 %       get_configuration_space_velocities - Gets the joint velocities of the robot in the CoppeliaSim scene.
 %       set_target_configuration_space_velocities - Sets the joint velocities of the robot in the CoppeliaSim scene as a target velocity for the joint controllers.
 %       set_configuration_space_torques - Sets the joint torques of the robot in the CoppeliaSim scene.
@@ -122,7 +122,7 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
         end
 
         function set_configuration_space_positions(obj, q)
-            % This method sets the joint configurations to the robot in the CoppeliaSim scene.
+            % This method sets the joint configurations of the robot in the CoppeliaSim scene.
             % Usage:
             %     set_configuration_space_positions(q);  
             %          q: The joint configurations of the robot in the CoppeliaSim scene.
@@ -155,7 +155,7 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
         end
 
         function set_target_configuration_space_positions(obj, q_target)
-            % This method sets the joint configurations to the robot in the CoppeliaSim scene as a target configuration for the joint controllers.
+            % This method sets the joint configurations of the robot in the CoppeliaSim scene as a target configuration for the joint controllers.
             % Usage:
             %     set_target_configuration_space_positions(q);  
             %          q_target: The target joint configurations of the robot in the CoppeliaSim scene.

--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -1,0 +1,236 @@
+% CLASS DQ_SerialVrepRobot - Concrete class to interface with serial robots
+% in VREP.
+%
+% Usage:
+%       1) Drag-and-drop a serial robot to a VREP scene. For instance, a
+%       "LBR4p" robot.
+%       2) Run
+%           >> vi = DQ_VrepInterface();
+%           >> vi.connect('127.0.0.1',19997);
+%           >> vrep_robot = LBR4pVrepRobot("LBR4p", vi);
+%           >> vi.start_simulation();
+%           >> robot.get_q_from_vrep();
+%           >> pause(1);
+%           >> vi.stop_simulation();
+%           >> vi.disconnect();
+%       Note that the name of the robot should be EXACTLY the same as in
+%       VREP. For instance, if you drag-and-drop a second robot, its name
+%       will become "LBR4p#0", a third robot, "LBR4p#1", and so on.
+%
+%   DQ_SerialVrepRobot Methods:
+%       send_q_to_vrep - Sends the joint configurations to VREP
+%       get_q_from_vrep - Obtains the joint configurations from VREP
+%       kinematics - Obtains the DQ_Kinematics implementation of this robot
+
+% (C) Copyright 2018-2023 DQ Robotics Developers
+%
+% This file is part of DQ Robotics.
+%
+%     DQ Robotics is free software: you can redistribute it and/or modify
+%     it under the terms of the GNU Lesser General Public License as published by
+%     the Free Software Foundation, either version 3 of the License, or
+%     (at your option) any later version.
+%
+%     DQ Robotics is distributed in the hope that it will be useful,
+%     but WITHOUT ANY WARRANTY; without even the implied warranty of
+%     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%     GNU Lesser General Public License for more details.
+%
+%     You should have received a copy of the GNU Lesser General Public License
+%     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
+%
+% DQ Robotics website: dqrobotics.github.io
+%
+% Contributors to this file:
+%     1. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+%        - Responsible for the original implementation.
+
+classdef DQ_SerialVrepRobot < DQ_VrepRobot
+    properties
+        joint_names;
+        base_frame_name;
+    end
+
+    methods
+        function obj = DQ_SerialVrepRobot(base_robot_name, robot_dof, robot_name, vrep_interface)
+            % This method constructs an instance of a DQ_SerialVrepRobot.
+            % Usage:
+            %     DQ_SerialVrepRobot(base_robot_name, robot_dof, robot_name, vrep_interface);  
+            %          base_robot_name: The base name of the robot in the CoppeliaSim scene.
+            %          robot_dof: The number of DoF of the robot in the CoppeliaSim scene.
+            %          robot_name: The name of the robot in the CoppeliaSim scene.
+            %          vrep_interface: The DQ_VrepInterface object connected to the CoppeliaSim scene.
+            %
+            % Example: 
+            %     vi = DQ_VrepInterface();
+            %     vi.connect('127.0.0.1',19997);
+            %     vrep_robot = DQ_SerialVrepRobot("my_robot", 7, "my_robot#1", vi);
+            %     
+            %     Note that the name of the robot should be EXACTLY the same as in the CoppeliaSim
+            %     scene. For instance, if you drag-and-drop a second robot, its name will become 
+            %     "my_robot#0", a third robot, "my_robot#1", and so on.
+
+            obj.robot_name = robot_name;
+            obj.vrep_interface = vrep_interface;
+
+            %% The use of 'initialize_joint_names_from_vrep()', as is done in the C++ implementation, is not supported on a constructor in MATLAB
+            % From the second copy of the robot and onward, VREP appends a
+            % #number in the robot's name. We check here if the robot is
+            % called by the correct name and assign an index that will be
+            % used to correctly infer the robot's joint labels.
+            splited_name = strsplit(obj.robot_name,'#');
+            robot_label = splited_name{1};
+            if ~strcmp(robot_label, base_robot_name)
+                error('Expected %s', base_robot_name)
+            end
+            if length(splited_name) > 1
+                robot_index = splited_name{2};
+            else
+                robot_index = '';
+            end
+            
+            % Initialize joint names, link names, and base frame name
+            obj.joint_names = {};
+            for i=1:robot_dof
+                current_joint_name = {robot_label,'_joint',int2str(i),'#',robot_index};
+                obj.joint_names{i} = strjoin(current_joint_name,'');
+
+                current_link_name = {robot_label,'_link',int2str(i+1),'#',robot_index};
+                obj.link_names{i} = strjoin(current_link_name,'');
+            end
+            obj.base_frame_name = obj.joint_names{1};
+        end
+
+        function joint_names = get_joint_names(obj)
+            % This method gets the joint names of the robot in the CoppeliaSim scene.
+            % Usage:
+            %     get_joint_names;
+            %
+            % Example: 
+            %     vi = DQ_VrepInterface();
+            %     vi.connect('127.0.0.1',19997);
+            %     vrep_robot = DQ_SerialVrepRobot("my_robot", 7, "my_robot#1", vi);
+            %     joint_names = vrep_robot.get_joint_names;
+
+            joint_names = obj.joint_names;
+        end
+
+        function set_configuration_space_positions(obj, q)
+            % This method sets the joint configurations to the robot in the CoppeliaSim scene.
+            % Usage:
+            %     set_configuration_space_positions(q);  
+            %          q: The joint configurations of the robot in the CoppeliaSim scene.
+            %
+            % Example: 
+            %     vi = DQ_VrepInterface();
+            %     vi.connect('127.0.0.1',19997);
+            %     vrep_robot = DQ_SerialVrepRobot("my_robot", 7, "my_robot#1", vi);
+            %     q = zeros(7,1);
+            %     vrep_robot.set_configuration_space_positions(q);
+            %     
+            %     Note that this calls "set_joint_positions" in the remoteAPI, meaning that it
+            %     is only suitable for passive joints.
+
+            obj.vrep_interface.set_joint_positions(obj.joint_names, q)
+        end
+        
+        function q = get_configuration_space_positions(obj)
+            % This method gets the joint configurations of the robot in the CoppeliaSim scene.
+            % Usage:
+            %     get_configuration_space_positions;  
+            %
+            % Example: 
+            %     vi = DQ_VrepInterface();
+            %     vi.connect('127.0.0.1',19997);
+            %     vrep_robot = DQ_SerialVrepRobot("my_robot", 7, "my_robot#1", vi);
+            %     q = vrep_robot.get_configuration_space_positions;
+
+            q = obj.vrep_interface.get_joint_positions(obj.joint_names);
+        end
+
+        function set_target_configuration_space_positions(obj, q_target)
+            % This method sets the joint configurations to the robot in the CoppeliaSim scene as a target configuration for the joint controllers.
+            % Usage:
+            %     set_target_configuration_space_positions(q);  
+            %          q_target: The target joint configurations of the robot in the CoppeliaSim scene.
+            %
+            % Example: 
+            %     vi = DQ_VrepInterface();
+            %     vi.connect('127.0.0.1',19997);
+            %     vrep_robot = DQ_SerialVrepRobot("my_robot", 7, "my_robot#1", vi);
+            %     q_target = zeros(7,1);
+            %     vrep_robot.set_target_configuration_space_positions(q_target);
+            %     
+            %     Note that this calls "set_joint_target_positions" in the remoteAPI, meaning that it
+            %     is only suitable for active joints.
+
+            obj.vrep_interface.set_joint_target_positions(obj.joint_names, q_target)
+        end
+        
+        function qd = get_configuration_space_velocities(obj)
+            % This method gets the joint velocities of the robot in the CoppeliaSim scene.
+            % Usage:
+            %     get_configuration_space_velocities;  
+            %
+            % Example: 
+            %     vi = DQ_VrepInterface();
+            %     vi.connect('127.0.0.1',19997);
+            %     vrep_robot = DQ_SerialVrepRobot("my_robot", 7, "my_robot#1", vi);
+            %     qd = vrep_robot.get_configuration_space_velocities;
+            
+            qd = obj.vrep_interface.get_joint_velocities(obj.joint_names);
+        end
+
+        function set_target_configuration_space_velocities(obj, v_target)
+            % This method sets the joint velocities of the robot in the CoppeliaSim scene as a target velocity for the joint controllers.
+            % Usage:
+            %     set_target_configuration_space_positions(q);  
+            %          v_target: The target joint velocities of the robot in the CoppeliaSim scene.
+            %
+            % Example: 
+            %     vi = DQ_VrepInterface();
+            %     vi.connect('127.0.0.1',19997);
+            %     vrep_robot = DQ_SerialVrepRobot("my_robot", 7, "my_robot#1", vi);
+            %     v_target = zeros(7,1);
+            %     vrep_robot.set_target_configuration_space_velocities(v_target);
+            %     
+            %     Note that this calls "set_joint_target_velocities" in the remoteAPI, meaning that it
+            %     is only suitable for active joints.
+
+            obj.vrep_interface.set_joint_target_velocities(obj.joint_names, v_target);
+        end
+
+        function set_configuration_space_torques(obj,tau)
+            % This method sets the joint torques of the robot in the CoppeliaSim scene.
+            % Usage:
+            %     set_target_configuration_space_positions(q);  
+            %          tau: The joint torques of the robot in the CoppeliaSim scene.
+            %
+            % Example: 
+            %     vi = DQ_VrepInterface();
+            %     vi.connect('127.0.0.1',19997);
+            %     vrep_robot = DQ_SerialVrepRobot("my_robot", 7, "my_robot#1", vi);
+            %     tau = zeros(7,1);
+            %     vrep_robot.set_configuration_space_torques(tau);
+            %     
+            %     Note that this calls "set_joint_torques" in the remoteAPI, meaning that it
+            %     is only suitable for active joints.
+
+            obj.vrep_interface.set_joint_torques(obj.joint_names,tau)
+        end
+
+        function tau = get_configuration_space_torques(obj)
+            % This method gets the joint torques of the robot in the CoppeliaSim scene.
+            % Usage:
+            %     get_configuration_space_torques;  
+            %
+            % Example: 
+            %     vi = DQ_VrepInterface();
+            %     vi.connect('127.0.0.1',19997);
+            %     vrep_robot = DQ_SerialVrepRobot("my_robot", 7, "my_robot#1", vi);
+            %     tau = vrep_robot.get_configuration_space_torques;
+
+            tau = obj.vrep_interface.get_joint_torques(obj.joint_names);
+        end
+    end
+end

--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -92,7 +92,7 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
             % Initialize joint names, link names, and base frame name
             obj.joint_names = {};
             for i=1:robot_dof
-                current_joint_name = {robot_label,'_joint',int2str(i),'#',robot_index};
+                current_joint_name = {robot_label,'_joint',int2str(i),robot_index};
                 obj.joint_names{i} = strjoin(current_joint_name,'');
             end
             obj.base_frame_name = obj.joint_names{1};

--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -26,8 +26,6 @@
 %       set_target_configuration_velocities - Sets the joint velocities of the robot in the CoppeliaSim scene as a target velocity for the joint controllers.
 %       set_configuration_space_torques - Sets the joint torques of the robot in the CoppeliaSim scene.
 %       get_configuration_space_torques - Gets the joint torques of the robot in the CoppeliaSim scene.
-%   DQ_SerialVrepRobot Methods (Protected):
-%       update_manipulator_dynamic_parameters - Updates the dynamic parameters of the serial robot in the CoppeliaSim scene
 
 % (C) Copyright 2011-2024 DQ Robotics Developers
 %

--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -19,7 +19,7 @@
 %
 %   DQ_SerialVrepRobot Methods:
 %       get_joint_names - Gets the joint names of the robot in the CoppeliaSim scene.
-%       set_configuration_space_positions - Sets the joint configurations of the robot in the CoppeliaSim scene.
+%       set_configuration - Sets the joint configurations of the robot in the CoppeliaSim scene.
 %       get_configuration - Gets the joint configurations of the robot in the CoppeliaSim scene.
 %       set_target_configuration_space_positions - Sets the joint configurations of the robot in the CoppeliaSim scene as a target configuration for the joint controllers.
 %       get_configuration_space_velocities - Gets the joint velocities of the robot in the CoppeliaSim scene.

--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -29,7 +29,7 @@
 %   DQ_SerialVrepRobot Methods (Protected):
 %       update_manipulator_dynamic_parameters - Updates the dynamic parameters of the serial robot in the CoppeliaSim scene
 
-% (C) Copyright 2018-2023 DQ Robotics Developers
+% (C) Copyright 2018-2024 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %

--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -23,7 +23,7 @@
 %       get_configuration - Gets the joint configurations of the robot in the CoppeliaSim scene.
 %       set_target_configuration - Sets the joint configurations of the robot in the CoppeliaSim scene as a target configuration for the joint controllers.
 %       get_configuration_velocities - Gets the joint velocities of the robot in the CoppeliaSim scene.
-%       set_target_configuration_space_velocities - Sets the joint velocities of the robot in the CoppeliaSim scene as a target velocity for the joint controllers.
+%       set_target_configuration_velocities - Sets the joint velocities of the robot in the CoppeliaSim scene as a target velocity for the joint controllers.
 %       set_configuration_space_torques - Sets the joint torques of the robot in the CoppeliaSim scene.
 %       get_configuration_space_torques - Gets the joint torques of the robot in the CoppeliaSim scene.
 %   DQ_SerialVrepRobot Methods (Protected):

--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -94,9 +94,6 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
             for i=1:robot_dof
                 current_joint_name = {robot_label,'_joint',int2str(i),'#',robot_index};
                 obj.joint_names{i} = strjoin(current_joint_name,'');
-
-                current_link_name = {robot_label,'_link',int2str(i+1),'#',robot_index};
-                obj.link_names{i} = strjoin(current_link_name,'');
             end
             obj.base_frame_name = obj.joint_names{1};
         end

--- a/interfaces/vrep/DQ_SerialVrepRobot.m
+++ b/interfaces/vrep/DQ_SerialVrepRobot.m
@@ -135,7 +135,7 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
             %     vrep_robot.set_configuration_space_positions(q);
             %     
             %     Note that this calls "set_joint_positions" in the remoteAPI, meaning that it
-            %     is only suitable for passive joints.
+            %     is only suitable for joints in kinematic mode.
 
             obj.vrep_interface.set_joint_positions(obj.joint_names, q)
         end
@@ -168,7 +168,7 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
             %     vrep_robot.set_target_configuration_space_positions(q_target);
             %     
             %     Note that this calls "set_joint_target_positions" in the remoteAPI, meaning that it
-            %     is only suitable for active joints.
+            %     is only suitable for joints in dynamic mode with position control.
 
             obj.vrep_interface.set_joint_target_positions(obj.joint_names, q_target)
         end
@@ -201,7 +201,7 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
             %     vrep_robot.set_target_configuration_space_velocities(v_target);
             %     
             %     Note that this calls "set_joint_target_velocities" in the remoteAPI, meaning that it
-            %     is only suitable for active joints.
+            %     is only suitable for joints in dynamic mode with velocity control.
 
             obj.vrep_interface.set_joint_target_velocities(obj.joint_names, v_target);
         end
@@ -220,7 +220,7 @@ classdef DQ_SerialVrepRobot < DQ_VrepRobot
             %     vrep_robot.set_configuration_space_torques(tau);
             %     
             %     Note that this calls "set_joint_torques" in the remoteAPI, meaning that it
-            %     is only suitable for active joints.
+            %     is only suitable for joints in dynamic mode with force/torque control.
 
             obj.vrep_interface.set_joint_torques(obj.joint_names,tau)
         end

--- a/interfaces/vrep/DQ_VrepRobot.m
+++ b/interfaces/vrep/DQ_VrepRobot.m
@@ -30,7 +30,16 @@
 % DQ Robotics website: dqrobotics.sourceforge.net
 %
 % Contributors to this file:
-%     Murilo Marques Marinho - murilo@nml.t.u-tokyo.ac.jp
+%     1. Murilo Marques Marinho - murilo@nml.t.u-tokyo.ac.jp
+%       - Responsible for the original implementation.
+%     2. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+%       - Altered the names of the following methods to ensure
+%       compatibility with the C++ version of the class:
+%             - 'send_q_to_vrep' became 'set_configuration_space_positions'
+%             - 'get_q_from_vrep' became 'get_configuration_space_positions'
+%       - Removed the following methods to ensure compatibility with the
+%       C++ version of the class:
+%             - 'kinematics'
 
 classdef (Abstract) DQ_VrepRobot
     
@@ -40,9 +49,8 @@ classdef (Abstract) DQ_VrepRobot
     end
     
     methods (Abstract)
-        send_q_to_vrep(obj,q);
-        q = get_q_from_vrep(obj);
-        kin = kinematics(obj);
+        set_configuration_space_positions(obj,q);
+        q = get_configuration_space_positions(obj);
     end
 end
 

--- a/interfaces/vrep/DQ_VrepRobot.m
+++ b/interfaces/vrep/DQ_VrepRobot.m
@@ -33,10 +33,10 @@
 %     1. Murilo Marques Marinho - murilo@nml.t.u-tokyo.ac.jp
 %       - Responsible for the original implementation.
 %     2. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
-%       - Altered the names of the following methods to ensure
-%       compatibility with the C++ version of the class:
-%             - 'send_q_to_vrep' became 'set_configuration_space_positions'
-%             - 'get_q_from_vrep' became 'get_configuration_space_positions'
+%       - Deprecated the following methods to ensure compatibility with the
+%       C++ version of the class:
+%             - 'send_q_to_vrep'
+%             - 'get_q_from_vrep'
 %       - Removed the following methods to ensure compatibility with the
 %       C++ version of the class:
 %             - 'kinematics'
@@ -51,6 +51,22 @@ classdef (Abstract) DQ_VrepRobot
     methods (Abstract)
         set_configuration_space_positions(obj,q);
         q = get_configuration_space_positions(obj);
+    end
+
+    methods
+        function send_q_to_vrep(obj, q)
+            % For backwards compatibility only. Do not use this method.
+
+            warning('Deprecated. Use set_configuration_space_positions() instead.')
+            obj.set_configuration_space_positions(q)
+        end
+
+        function q = get_q_from_vrep(obj)
+            % For backwards compatibility only. Do not use this method.
+
+            warning('Deprecated. Use get_configuration_space_positions() instead.')
+            q = obj.get_configuration_space_positions();
+        end
     end
 end
 

--- a/interfaces/vrep/DQ_VrepRobot.m
+++ b/interfaces/vrep/DQ_VrepRobot.m
@@ -4,13 +4,11 @@
 % Usage:
 %   Inherit from this class and implement the abstract methods.
 %
-%   DQ_VrepRobot Methods:
-%       send_q_to_vrep - Sends the joint configurations to VREP
-%       get_q_from_vrep - Obtains the joint configurations from VREP
-%       kinematics - Obtains the DQ_Kinematics implementation of this
-%       robot
+%   DQ_VrepRobot Methods (Abstract):
+%       set_configuration_space_positions - Sends the joint configurations to VREP
+%       get_configuration_space_positions - Obtains the joint configurations from VREP
 
-% (C) Copyright 2020 DQ Robotics Developers
+% (C) Copyright 2018-2024 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %

--- a/interfaces/vrep/DQ_VrepRobot.m
+++ b/interfaces/vrep/DQ_VrepRobot.m
@@ -5,8 +5,8 @@
 %   Inherit from this class and implement the abstract methods.
 %
 %   DQ_VrepRobot Methods (Abstract):
-%       set_configuration_space_positions - Sends the joint configurations to VREP
-%       get_configuration_space_positions - Obtains the joint configurations from VREP
+%       set_configuration - Sends the joint configurations to VREP
+%       get_configuration - Obtains the joint configurations from VREP
 
 % (C) Copyright 2018-2024 DQ Robotics Developers
 %
@@ -47,23 +47,23 @@ classdef (Abstract) DQ_VrepRobot
     end
     
     methods (Abstract)
-        set_configuration_space_positions(obj,q);
-        q = get_configuration_space_positions(obj);
+        set_configuration(obj,q);
+        q = get_configuration(obj);
     end
 
     methods
         function send_q_to_vrep(obj, q)
             % For backwards compatibility only. Do not use this method.
 
-            warning('Deprecated. Use set_configuration_space_positions() instead.')
-            obj.set_configuration_space_positions(q)
+            warning('Deprecated. Use set_configuration() instead.')
+            obj.set_configuration(q)
         end
 
         function q = get_q_from_vrep(obj)
             % For backwards compatibility only. Do not use this method.
 
-            warning('Deprecated. Use get_configuration_space_positions() instead.')
-            q = obj.get_configuration_space_positions();
+            warning('Deprecated. Use get_configuration() instead.')
+            q = obj.get_configuration();
         end
     end
 end

--- a/interfaces/vrep/robots/LBR4pVrepRobot.m
+++ b/interfaces/vrep/robots/LBR4pVrepRobot.m
@@ -8,7 +8,7 @@
 %           >> vi.connect('127.0.0.1',19997);
 %           >> vrep_robot = LBR4pVrepRobot("LBR4p", vi);
 %           >> vi.start_simulation();
-%           >> robot.get_q_from_vrep();
+%           >> robot.get_configuration_space_positions();
 %           >> pause(1);
 %           >> vi.stop_simulation();
 %           >> vi.disconnect();
@@ -17,8 +17,6 @@
 %       will become "LBR4p#0", a third robot, "LBR4p#1", and so on.
 %
 %   LBR4pVrepRobot Methods:
-%       send_q_to_vrep - Sends the joint configurations to VREP
-%       get_q_from_vrep - Obtains the joint configurations from VREP
 %       kinematics - Obtains the DQ_Kinematics implementation of this robot
 
 % (C) Copyright 2020 DQ Robotics Developers

--- a/interfaces/vrep/robots/LBR4pVrepRobot.m
+++ b/interfaces/vrep/robots/LBR4pVrepRobot.m
@@ -19,7 +19,7 @@
 %   LBR4pVrepRobot Methods:
 %       kinematics - Obtains the DQ_Kinematics implementation of this robot
 
-% (C) Copyright 2018-2024 DQ Robotics Developers
+% (C) Copyright 2011-2024 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %

--- a/interfaces/vrep/robots/LBR4pVrepRobot.m
+++ b/interfaces/vrep/robots/LBR4pVrepRobot.m
@@ -19,7 +19,7 @@
 %   LBR4pVrepRobot Methods:
 %       kinematics - Obtains the DQ_Kinematics implementation of this robot
 
-% (C) Copyright 2020 DQ Robotics Developers
+% (C) Copyright 2018-2024 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %

--- a/interfaces/vrep/robots/LBR4pVrepRobot.m
+++ b/interfaces/vrep/robots/LBR4pVrepRobot.m
@@ -41,67 +41,21 @@
 % DQ Robotics website: dqrobotics.sourceforge.net
 %
 % Contributors to this file:
-%     Murilo Marques Marinho - murilo@nml.t.u-tokyo.ac.jp
+%     1. Murilo Marques Marinho - murilo@nml.t.u-tokyo.ac.jp
+%        - Responsible for the original implementation
+%     2. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+%        - Updated for compatibility with the DQ_SerialVrepRobot class.
 
-classdef LBR4pVrepRobot < DQ_VrepRobot
-    
-    properties
-        joint_names;
-        base_frame_name;
-    end
-    
+classdef LBR4pVrepRobot < DQ_SerialVrepRobot
     methods
-        function obj = LBR4pVrepRobot(robot_name,vrep_interface)
-            %% Constructs an instance of a LBR4pVrepRobot
-            %  >> vi = VrepInterface()
-            %  >> vi.connect('127.0.0.1',19997);
-            %  >> robot = LBR4pVrepRobot("LBR4p", vi)
-            obj.robot_name = robot_name;
-            obj.vrep_interface = vrep_interface;
-            
-            % From the second copy of the robot and onward, VREP appends a
-            % #number in the robot's name. We check here if the robot is
-            % called by the correct name and assign an index that will be
-            % used to correctly infer the robot's joint labels.
-            splited_name = strsplit(robot_name,'#');
-            robot_label = splited_name{1};
-            if ~strcmp(robot_label,'LBR4p')
-                error('Expected LBR4p')
-            end
-            if length(splited_name) > 1
-                robot_index = splited_name{2};
-            else
-                robot_index = '';
-            end
-            
-            % Initialize joint names and base frame
-            obj.joint_names = {};
-            for i=1:7
-                current_joint_name = {robot_label,'_joint',int2str(i),robot_index};
-                obj.joint_names{i} = strjoin(current_joint_name,'');
-            end
-            obj.base_frame_name = obj.joint_names{1};
+        function obj = LBR4pVrepRobot(robot_name, vrep_interface)
+            obj@DQ_SerialVrepRobot("LBR4p", 7, robot_name, vrep_interface);
         end
-        
-        function send_q_to_vrep(obj,q)
-            %% Sends the joint configurations to VREP
-            %  >> vrep_robot = LBR4pVrepRobot("LBR4p", vi)
-            %  >> q = zeros(7,1);
-            %  >> vrep_robot.send_q_to_vrep(q)
-            obj.vrep_interface.set_joint_positions(obj.joint_names,q)
-        end
-        
-        function q = get_q_from_vrep(obj)
-            %% Obtains the joint configurations from VREP
-            %  >> vrep_robot = LBR4pVrepRobot("LBR4p", vi)
-            %  >> q = vrep_robot.get_q_from_vrep(q)
-            q = obj.vrep_interface.get_joint_positions(obj.joint_names);
-        end
-        
+
         function kin = kinematics(obj)
             %% Obtains the DQ_SerialManipulator instance that represents this LBR4p robot.
-            %  >> vrep_robot = LBR4pVrepRobot("LBR4p", vi)
-            %  >> robot_kinematics = vrep_robot.kinematics()
+            %  >> vrep_robot = LBR4pVrepRobot("LBR4p", vi);
+            %  >> robot_kinematics = vrep_robot.kinematics();
             
             LBR4p_DH_theta=[0, 0, 0, 0, 0, 0, 0];
             LBR4p_DH_d = [0.200, 0, 0.4, 0, 0.39, 0, 0];
@@ -119,8 +73,7 @@ classdef LBR4pVrepRobot < DQ_VrepRobot
             kin.set_reference_frame(obj.vrep_interface.get_object_pose(obj.base_frame_name));
             kin.set_base_frame(obj.vrep_interface.get_object_pose(obj.base_frame_name));
             kin.set_effector(1+0.5*DQ.E*DQ.k*0.07);
-        end
-        
+        end        
     end
 end
 

--- a/interfaces/vrep/robots/LBR4pVrepRobot.m
+++ b/interfaces/vrep/robots/LBR4pVrepRobot.m
@@ -8,7 +8,7 @@
 %           >> vi.connect('127.0.0.1',19997);
 %           >> vrep_robot = LBR4pVrepRobot("LBR4p", vi);
 %           >> vi.start_simulation();
-%           >> robot.get_configuration_space_positions();
+%           >> robot.get_configuration();
 %           >> pause(1);
 %           >> vi.stop_simulation();
 %           >> vi.disconnect();

--- a/interfaces/vrep/robots/YouBotVrepRobot.m
+++ b/interfaces/vrep/robots/YouBotVrepRobot.m
@@ -53,7 +53,7 @@ classdef YouBotVrepRobot < DQ_SerialVrepRobot
     
     methods
         function obj = YouBotVrepRobot(robot_name, vrep_interface)
-            obj@DQ_SerialVrepRobot("youBot", 7, robot_name, vrep_interface);
+            obj@DQ_SerialVrepRobot("youBot", 5, robot_name, vrep_interface);
             
             %% youBot does not follow the standard naming convention in CoppeliaSim. Also, the use of 'set_names()', as is done in the C++ implementation, is not supported on a constructor in MATLAB
             % From the second copy of the robot and onward, VREP appends a
@@ -77,6 +77,7 @@ classdef YouBotVrepRobot < DQ_SerialVrepRobot
                 current_joint_name = {robot_label,'ArmJoint',int2str(i-1),robot_index};
                 obj.joint_names{i} = strjoin(current_joint_name,'');
             end
+            obj.base_frame_name = robot_name;
         end
         
         function set_configuration_space_positions(obj,q)

--- a/interfaces/vrep/robots/YouBotVrepRobot.m
+++ b/interfaces/vrep/robots/YouBotVrepRobot.m
@@ -17,7 +17,7 @@
 %       will become "youBot#0", a third robot, "youBot#1", and so on.
 %
 %   YouBotVrepRobot Methods:
-%       set_configuration_space_positions - Sends the joint configurations to VREP
+%       set_configuration - Sends the joint configurations to VREP
 %       get_configuration - Obtains the joint configurations from VREP
 %       kinematics - Obtains the DQ_Kinematics implementation of this robot
 
@@ -80,11 +80,11 @@ classdef YouBotVrepRobot < DQ_SerialVrepRobot
             obj.base_frame_name = robot_name;
         end
         
-        function set_configuration_space_positions(obj,q)
+        function set_configuration(obj,q)
             %% Sends the joint configurations to VREP
             %  >> vrep_robot = YouBotVrepRobot("youBot", vi)
             %  >> q = zeros(8,1);
-            %  >> vrep_robot.set_configuration_space_positions(q)
+            %  >> vrep_robot.set_configuration(q)
             x = q(1);
             y = q(2);
             phi = q(3);

--- a/interfaces/vrep/robots/YouBotVrepRobot.m
+++ b/interfaces/vrep/robots/YouBotVrepRobot.m
@@ -55,7 +55,7 @@ classdef YouBotVrepRobot < DQ_SerialVrepRobot
         function obj = YouBotVrepRobot(robot_name, vrep_interface)
             obj@DQ_SerialVrepRobot("youBot", 7, robot_name, vrep_interface);
             
-            %% youBot don't follow the standard name convention on CoppeliaSim. Also, the use of 'set_names()', as is done in the C++ implementation, is not supported on a constructor in MATLAB
+            %% youBot does not follow the standard naming convention in CoppeliaSim. Also, the use of 'set_names()', as is done in the C++ implementation, is not supported on a constructor in MATLAB
             % From the second copy of the robot and onward, VREP appends a
             % #number in the robot's name. We check here if the robot is
             % called by the correct name and assign an index that will be

--- a/interfaces/vrep/robots/YouBotVrepRobot.m
+++ b/interfaces/vrep/robots/YouBotVrepRobot.m
@@ -21,7 +21,7 @@
 %       get_configuration - Obtains the joint configurations from VREP
 %       kinematics - Obtains the DQ_Kinematics implementation of this robot
 
-% (C) Copyright 2018-2024 DQ Robotics Developers
+% (C) Copyright 2011-2024 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %

--- a/interfaces/vrep/robots/YouBotVrepRobot.m
+++ b/interfaces/vrep/robots/YouBotVrepRobot.m
@@ -8,7 +8,7 @@
 %           >> vi.connect('127.0.0.1',19997);
 %           >> vrep_robot = YouBotVrepRobot("youBot", vi);
 %           >> vi.start_simulation();
-%           >> robot.get_configuration_space_positions();
+%           >> robot.get_configuration();
 %           >> pause(1);
 %           >> vi.stop_simulation();
 %           >> vi.disconnect();
@@ -18,7 +18,7 @@
 %
 %   YouBotVrepRobot Methods:
 %       set_configuration_space_positions - Sends the joint configurations to VREP
-%       get_configuration_space_positions - Obtains the joint configurations from VREP
+%       get_configuration - Obtains the joint configurations from VREP
 %       kinematics - Obtains the DQ_Kinematics implementation of this robot
 
 % (C) Copyright 2018-2024 DQ Robotics Developers
@@ -97,10 +97,10 @@ classdef YouBotVrepRobot < DQ_SerialVrepRobot
             obj.vrep_interface.set_object_pose(obj.base_frame_name, pose * obj.adjust');
         end
         
-        function q = get_configuration_space_positions(obj)
+        function q = get_configuration(obj)
             %% Obtains the joint configurations from VREP
             %  >> vrep_robot = YouBotVrepRobot("youBot", vi)
-            %  >> q = vrep_robot.get_configuration_space_positions(q)
+            %  >> q = vrep_robot.get_configuration(q)
             base_x = obj.vrep_interface.get_object_pose(obj.base_frame_name) * obj.adjust;
             base_t = vec3(translation(base_x));
             base_phi = rotation_angle(rotation(base_x));

--- a/interfaces/vrep/robots/YouBotVrepRobot.m
+++ b/interfaces/vrep/robots/YouBotVrepRobot.m
@@ -50,9 +50,12 @@ classdef YouBotVrepRobot < DQ_SerialVrepRobot
     properties (Constant)
         adjust = ((cos(pi/2) + DQ.i*sin(pi/2)) * (cos(pi/4) + DQ.j*sin(pi/4)))*(1+0.5*DQ.E*-0.1*DQ.k);
     end
-
-    methods (Access = protected)
-        function set_names(robot_name)
+    
+    methods
+        function obj = YouBotVrepRobot(robot_name, vrep_interface)
+            obj@DQ_SerialVrepRobot("youBot", 7, robot_name, vrep_interface);
+            
+            %% youBot don't follow the standard name convention on CoppeliaSim. Also, the use of 'set_names()', as is done in the C++ implementation, is not supported on a constructor in MATLAB
             % From the second copy of the robot and onward, VREP appends a
             % #number in the robot's name. We check here if the robot is
             % called by the correct name and assign an index that will be
@@ -74,13 +77,6 @@ classdef YouBotVrepRobot < DQ_SerialVrepRobot
                 current_joint_name = {robot_label,'ArmJoint',int2str(i-1),robot_index};
                 obj.joint_names{i} = strjoin(current_joint_name,'');
             end
-        end
-    end
-    
-    methods
-        function obj = YouBotVrepRobot(robot_name, vrep_interface)
-            obj@DQ_SerialVrepRobot("youBot", 7, robot_name, vrep_interface);
-            obj.set_names(robot_name);
         end
         
         function set_configuration_space_positions(obj,q)

--- a/interfaces/vrep/robots/YouBotVrepRobot.m
+++ b/interfaces/vrep/robots/YouBotVrepRobot.m
@@ -8,7 +8,7 @@
 %           >> vi.connect('127.0.0.1',19997);
 %           >> vrep_robot = YouBotVrepRobot("youBot", vi);
 %           >> vi.start_simulation();
-%           >> robot.get_q_from_vrep();
+%           >> robot.get_configuration_space_positions();
 %           >> pause(1);
 %           >> vi.stop_simulation();
 %           >> vi.disconnect();
@@ -21,7 +21,7 @@
 %       get_configuration_space_positions - Obtains the joint configurations from VREP
 %       kinematics - Obtains the DQ_Kinematics implementation of this robot
 
-% (C) Copyright 2020 DQ Robotics Developers
+% (C) Copyright 2018-2024 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %


### PR DESCRIPTION
# Main instructions

By submitting this pull request, you automatically agree that you have read and accepted the following conditions:

- Anyone wanting to propose a new modification or introduce new functionality should reach out to the team first, as proposed modifications that do not comply with the library's development philosophy and style, do not follow the library's architecture, do not introduce a clear and general benefit to the library other than to the person who proposed the modification will likely be rejected with no further discussion.
- Support for DQ Robotics is given voluntarily and it is not the developers' role to educate and/or convince anyone of their vision.
- Any possible response and its timeliness will be based on the relevance, accuracy, and politeness of a request and the following discussion.
- You are familiar with the [development workflow](https://github.com/dqrobotics/matlab/blob/master/CONTRIBUTING.md).
- Each pull request should contain only individual changes (several changes of the same type **are allowed** on the same pull request).
- Refactoring or modifying internal implementation that is working is not allowed unless comprehensively discussed with and approved by @bvadorno and @mmmarinho.


## Description of changes
Hi, @dqrobotics/developers,

I've added the the class `DQ_SerialVrepRobot`. It follows the implementation of its [C++ counterpart](https://github.com/dqrobotics/cpp-interface-vrep/blob/master/src/dqrobotics/interfaces/vrep/DQ_VrepRobot.cpp).

I also had to update the classes `DQ_VrepRobot`, `LBR4pVrepRobot`, and `YouBotVrepRobot` for compatibility with the new signatures imposed by `DQ_SerialVrepRobot`. 

An example of use is given in [9](https://github.com/dqrobotics/matlab-examples/pull/9).

## Rationale
The class `DQ_SerialVrepRobot` already exists in the C++ library but was missing on MATLAB.