### PR TITLE
This PR adds methods to get an object's inertial parameters in CoppeliaSim to the class 'DQ_VrepInterface'

### DIFF
--- a/interfaces/vrep/DQ_VrepInterface.m
+++ b/interfaces/vrep/DQ_VrepInterface.m
@@ -152,6 +152,61 @@ classdef DQ_VrepInterface < handle
     end
     
     methods (Access = private)
+        function [return_code, output_ints, output_doubles, output_strings] = call_script_function(obj, function_name, obj_name, input_ints, input_floats, input_strings, script_type, opmode)
+            % This method calls a LUA script function in CoppeliaSim.
+            %
+            % Usage:
+            %     Recommended:
+            %      [return_code, output_ints, output_doubles, output_strings] = call_script_function(function_name, obj_name, input_ints, input_floats, input_strings, script_type)
+            %
+            %     Advanced:
+            %      [return_code, output_ints, output_doubles, output_strings] = call_script_function(function_name, obj_name, input_ints, input_floats, input_strings, script_type, opmode)
+            %
+            %          function_name: The name of the script function to call in the specified script.
+            %          obj_name: The name of the object where the script is attached to.
+            %          input_ints: The input integer values.
+            %          input_floats: The input floating-point values.
+            %          input_strings: The input strings.
+            %          script_type: The type of the script.
+            %
+            %            You can use the following types:
+            %               ST_CHILD 
+            %
+            %          (optional) opmode: The operation mode. If not
+            %            specified, the opmode will be set automatically.
+            %
+            %            You can use the following modes:
+            %               OP_BLOCKING 
+            %               OP_STREAMING 
+            %               OP_ONESHOT 
+            %               OP_BUFFER;
+            %
+            %
+            %     Check this link for more details: https://www.coppeliarobotics.com/helpFiles/en/remoteApiFunctionsMatlab.htm#simxCallScriptFunction
+            %
+            % Example:
+            %      input_ints = [];
+            %      input_floats = [];
+            %      input_strings = [];
+            %
+            %      % Recommended:
+            %      [rtn, output_ints, output_doubles, output_strings] = call_script_function('my_function_name', 'DQRoboticsApiCommandServer', input_ints, input_floats, input_strings, ST_CHILD)
+            %
+            %      % For advanced usage:
+            %      [rtn, output_ints, output_doubles, output_strings] = call_script_function('my_function_name', 'DQRoboticsApiCommandServer', input_ints, input_floats, input_strings, ST_CHILD, OP_BLOCKING)
+            
+            % If the user does not specify the opmode, it is chosen as
+            % OP_BLOCKING as specified by the remote API documentation.
+            if nargin == 8
+                [return_code, output_ints, output_floats, output_strings, ~] = obj.vrep.simxCallScriptFunction(obj.clientID, obj_name, ...
+                                                                                script_type, function_name, input_ints, input_floats , input_strings, [], obj.OP_BLOCKING);
+                output_doubles = double(output_floats);
+            else
+                [return_code, output_ints, output_floats, output_strings, ~] = obj.vrep.simxCallScriptFunction(obj.clientID, obj_name, ...
+                                                                                script_type, function_name, input_ints, input_floats , input_strings, [], opmode);
+                output_doubles = double(output_floats);
+            end
+        end
         
         function handle = handle_from_string_or_handle(obj,name_or_handle)
             if(ischar(name_or_handle))
@@ -182,67 +237,6 @@ classdef DQ_VrepInterface < handle
             obj.clientID = -1;
             disp(['This version of DQ Robotics DQ_VrepInterface is compatible'...
                 ' with VREP 3.5.0']);
-        end
-
-        function [return_code,output_ints,output_doubles,output_strings,retBuffer] = call_script_function(obj,obj_name,script_type,function_name,...
-                                                                                       input_ints,input_floats,input_strings,input_buffer,opmode)
-            % This method calls a LUA script function in V-REP.
-            %
-            % Usage:
-            %     Recommended:
-            %      [return_code,output_ints,output_doubles,output_strings,retBuffer] = call_script_function(obj_name, script_type, function_name, input_ints, input_floats, input_strings, input_buffer)
-            %
-            %     Advanced:
-            %      [return_code,output_ints,output_doubles,output_strings,retBuffer] = call_script_function(obj_name, script_type, function_name, input_ints, input_floats, input_strings, input_buffer, opmode)
-            %
-            %          obj_name: The name of the object where the script is
-            %          attached to.
-            %          script_type: The type of the script.
-            %
-            %            You can use the following types:
-            %               ST_CHILD 
-            %
-            %          function_name: The name of the script function to
-            %          call in the specified script.
-            %          input_ints: The input integer values.
-            %          input_floats: The input floating-point values.
-            %          input_strings: The input strings.
-            %          input_buffer: The input buffer.
-            %          (optional) opmode: The operation mode. If not
-            %            specified, the opmode will be set automatically.
-            %
-            %            You can use the following modes:
-            %               OP_BLOCKING 
-            %               OP_STREAMING 
-            %               OP_ONESHOT 
-            %               OP_BUFFER;
-            %
-            %
-            %     Check this link for more details: https://www.coppeliarobotics.com/helpFiles/en/remoteApiFunctionsMatlab.htm#simxCallScriptFunction
-            %
-            % Example:
-            %      input_ints = [];
-            %      input_floats = [];
-            %      input_strings = [];
-            %      input_buffer = [];
-            %
-            %      % Recommended:
-            %      [rtn, output_ints, output_doubles, output_strings, retBuffer] = call_script_function('DQRoboticsApiCommandServer', ST_CHILD, 'my_function_name', input_ints, input_floats, input_strings, input_buffer)
-            %
-            %      % For advanced usage:
-            %      [rtn, output_ints, output_doubles, output_strings, retBuffer] = call_script_function('DQRoboticsApiCommandServer', ST_CHILD, 'my_function_name', input_ints, input_floats, input_strings, input_buffer, OP_BLOCKING)
-            
-            % If the user does not specify the opmode, it is chosen as
-            % OP_BLOCKING as specified by the remote API documentation.
-            if nargin == 8
-                [return_code,output_ints,output_floats,output_strings,retBuffer] = obj.vrep.simxCallScriptFunction(obj.clientID, obj_name, ...
-                                                script_type, function_name, input_ints, input_floats , input_strings, input_buffer, obj.OP_BLOCKING);
-                output_doubles = double(output_floats);
-            else
-                [return_code,output_ints,output_floats,output_strings,retBuffer] = obj.vrep.simxCallScriptFunction(obj.clientID, obj_name, ...
-                                                script_type, function_name, input_ints, input_floats , input_strings, input_buffer, opmode);
-                output_doubles = double(output_floats);
-            end
         end
         
         function connect(obj,ip,port)

--- a/interfaces/vrep/DQ_VrepInterface.m
+++ b/interfaces/vrep/DQ_VrepInterface.m
@@ -781,28 +781,25 @@ classdef DQ_VrepInterface < handle
                 [return_code, ~, center_of_mass, ~] = obj.call_script_function('get_center_of_mass', obj.DF_LUA_SCRIPT_API, obj_handle, [], [], obj.ST_CHILD);
             elseif nargin == 3 % the call was: center_of_mass = get_center_of_mass(objectname, reference_frame)
                 if(reference_frame == obj.ABSOLUTE_FRAME)
-                    ref_frame_handle = -1;
+                    [return_code, ~, center_of_mass, ~] = obj.call_script_function('get_center_of_mass', obj.DF_LUA_SCRIPT_API, obj_handle, [], obj.ABSOLUTE_FRAME, obj.ST_CHILD);
                 else
                     ref_frame_handle = obj.handle_from_string_or_handle(reference_frame);
+                    [return_code, ~, center_of_mass, ~] = obj.call_script_function('get_center_of_mass', obj.DF_LUA_SCRIPT_API, [obj_handle, ref_frame_handle], [], [], obj.ST_CHILD);
                 end
-
-                [return_code, ~, center_of_mass, ~] = obj.call_script_function('get_center_of_mass', obj.DF_LUA_SCRIPT_API, [obj_handle, ref_frame_handle], [], [], obj.ST_CHILD);
             elseif nargin == 4 % the call was: center_of_mass = get_center_of_mass(objectname, reference_frame, function_name)
                 if(reference_frame == obj.ABSOLUTE_FRAME)
-                    ref_frame_handle = -1;
+                    [return_code, ~, center_of_mass, ~] = obj.call_script_function(function_name, obj.DF_LUA_SCRIPT_API, obj_handle, [], obj.ABSOLUTE_FRAME, obj.ST_CHILD);
                 else
                     ref_frame_handle = obj.handle_from_string_or_handle(reference_frame);
+                    [return_code, ~, center_of_mass, ~] = obj.call_script_function(function_name, obj.DF_LUA_SCRIPT_API, [obj_handle, ref_frame_handle], [], [], obj.ST_CHILD);
                 end
-
-                [return_code, ~, center_of_mass, ~] = obj.call_script_function(function_name, obj.DF_LUA_SCRIPT_API, [obj_handle, ref_frame_handle], [], [], obj.ST_CHILD);
             else % the call was: center_of_mass = get_center_of_mass(objectname, reference_frame, function_name, obj_name)
                 if(reference_frame == obj.ABSOLUTE_FRAME)
-                    ref_frame_handle = -1;
+                    [return_code, ~, center_of_mass, ~] = obj.call_script_function(function_name, obj_script_name, obj_handle, [], obj.ABSOLUTE_FRAME, obj.ST_CHILD);
                 else
                     ref_frame_handle = obj.handle_from_string_or_handle(reference_frame);
+                    [return_code, ~, center_of_mass, ~] = obj.call_script_function(function_name, obj_script_name, [obj_handle, ref_frame_handle], [], [], obj.ST_CHILD);
                 end
-
-                [return_code, ~, center_of_mass, ~] = obj.call_script_function(function_name, obj_script_name, [obj_handle, ref_frame_handle], [], [], obj.ST_CHILD);
             end
 
             if(return_code ~= 0)

--- a/interfaces/vrep/DQ_VrepInterface.m
+++ b/interfaces/vrep/DQ_VrepInterface.m
@@ -101,13 +101,13 @@
 %
 %     3. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
 %       - Added the following methods:
-%             - call_script_function() (see https://github.com/dqrobotics/matlab/pull/XXX)
-%             - get_center_of_mass() (see https://github.com/dqrobotics/matlab/pull/XXX)
-%             - get_mass() (see https://github.com/dqrobotics/matlab/pull/XXX)
-%             - get_inertia_matrix() (see https://github.com/dqrobotics/matlab/pull/XXX)
+%             - call_script_function() (see https://github.com/dqrobotics/matlab/pull/109)
+%             - get_center_of_mass() (see https://github.com/dqrobotics/matlab/pull/109)
+%             - get_mass() (see https://github.com/dqrobotics/matlab/pull/109)
+%             - get_inertia_matrix() (see https://github.com/dqrobotics/matlab/pull/109)
 %       - Added the following properties:
-%             - DF_LUA_SCRIPT_API (see https://github.com/dqrobotics/matlab/pull/XXX)
-%             - ST_CHILD (see https://github.com/dqrobotics/matlab/pull/XXX)
+%             - DF_LUA_SCRIPT_API (see https://github.com/dqrobotics/matlab/pull/109)
+%             - ST_CHILD (see https://github.com/dqrobotics/matlab/pull/109)
 %       - Altered the following properties from 'private' to 'protected'
 %       (see discussions in https://github.com/dqrobotics/matlab/pull/101
 %       to further details):

--- a/interfaces/vrep/DQ_VrepInterface.m
+++ b/interfaces/vrep/DQ_VrepInterface.m
@@ -780,22 +780,28 @@ classdef DQ_VrepInterface < handle
             if nargin == 2 % the call was: center_of_mass = get_center_of_mass(objectname)
                 [return_code, ~, center_of_mass, ~] = obj.call_script_function('get_center_of_mass', obj.DF_LUA_SCRIPT_API, obj_handle, [], [], obj.ST_CHILD);
             elseif nargin == 3 % the call was: center_of_mass = get_center_of_mass(objectname, reference_frame)
-                if(reference_frame == obj.ABSOLUTE_FRAME)
+                if(strcmp(reference_frame, obj.ABSOLUTE_FRAME))
                     [return_code, ~, center_of_mass, ~] = obj.call_script_function('get_center_of_mass', obj.DF_LUA_SCRIPT_API, obj_handle, [], obj.ABSOLUTE_FRAME, obj.ST_CHILD);
+                elseif(strcmp(reference_frame, obj.BODY_FRAME))
+                    [return_code, ~, center_of_mass, ~] = obj.call_script_function('get_center_of_mass', obj.DF_LUA_SCRIPT_API, [obj_handle, obj_handle], [], [], obj.ST_CHILD);
                 else
                     ref_frame_handle = obj.handle_from_string_or_handle(reference_frame);
                     [return_code, ~, center_of_mass, ~] = obj.call_script_function('get_center_of_mass', obj.DF_LUA_SCRIPT_API, [obj_handle, ref_frame_handle], [], [], obj.ST_CHILD);
                 end
             elseif nargin == 4 % the call was: center_of_mass = get_center_of_mass(objectname, reference_frame, function_name)
-                if(reference_frame == obj.ABSOLUTE_FRAME)
+                if(strcmp(reference_frame, obj.ABSOLUTE_FRAME))
                     [return_code, ~, center_of_mass, ~] = obj.call_script_function(function_name, obj.DF_LUA_SCRIPT_API, obj_handle, [], obj.ABSOLUTE_FRAME, obj.ST_CHILD);
+                elseif(strcmp(reference_frame, obj.BODY_FRAME))
+                    [return_code, ~, center_of_mass, ~] = obj.call_script_function(function_name, obj.DF_LUA_SCRIPT_API, [obj_handle, obj_handle], [], [], obj.ST_CHILD);
                 else
                     ref_frame_handle = obj.handle_from_string_or_handle(reference_frame);
                     [return_code, ~, center_of_mass, ~] = obj.call_script_function(function_name, obj.DF_LUA_SCRIPT_API, [obj_handle, ref_frame_handle], [], [], obj.ST_CHILD);
                 end
             else % the call was: center_of_mass = get_center_of_mass(objectname, reference_frame, function_name, obj_name)
-                if(reference_frame == obj.ABSOLUTE_FRAME)
+                if(strcmp(reference_frame, obj.ABSOLUTE_FRAME))
                     [return_code, ~, center_of_mass, ~] = obj.call_script_function(function_name, obj_script_name, obj_handle, [], obj.ABSOLUTE_FRAME, obj.ST_CHILD);
+                elseif(strcmp(reference_frame, obj.BODY_FRAME))
+                    [return_code, ~, center_of_mass, ~] = obj.call_script_function(function_name, obj_script_name, [obj_handle, obj_handle], [], [], obj.ST_CHILD);
                 else
                     ref_frame_handle = obj.handle_from_string_or_handle(reference_frame);
                     [return_code, ~, center_of_mass, ~] = obj.call_script_function(function_name, obj_script_name, [obj_handle, ref_frame_handle], [], [], obj.ST_CHILD);
@@ -900,22 +906,28 @@ classdef DQ_VrepInterface < handle
             if nargin == 2 % the call was: inertia_tensor =  get_inertia_matrix(objectname)
                 [return_code, ~, inertia_tensor, ~] = obj.call_script_function('get_inertia', obj.DF_LUA_SCRIPT_API, obj_handle, [], [], obj.ST_CHILD);
             elseif nargin == 3 % the call was: inertia_tensor =  get_inertia_matrix(objectname, reference_frame)
-                if(reference_frame == obj.ABSOLUTE_FRAME)
+                if(strcmp(reference_frame, obj.ABSOLUTE_FRAME))
                     [return_code, ~, inertia_tensor, ~] = obj.call_script_function('get_inertia', obj.DF_LUA_SCRIPT_API, obj_handle, [], obj.ABSOLUTE_FRAME, obj.ST_CHILD);
+                elseif(strcmp(reference_frame, obj.BODY_FRAME))
+                    [return_code, ~, inertia_tensor, ~] = obj.call_script_function('get_inertia', obj.DF_LUA_SCRIPT_API, [obj_handle, obj_handle], [], [], obj.ST_CHILD);
                 else
                     ref_frame_handle = obj.handle_from_string_or_handle(reference_frame);
                     [return_code, ~, inertia_tensor, ~] = obj.call_script_function('get_inertia', obj.DF_LUA_SCRIPT_API, [obj_handle, ref_frame_handle], [], [], obj.ST_CHILD);
                 end
             elseif nargin == 4 % the call was: inertia_tensor =  get_inertia_matrix(objectname, reference_frame, function_name)
-                if(reference_frame == obj.ABSOLUTE_FRAME)
+                if(strcmp(reference_frame, obj.ABSOLUTE_FRAME))
                     [return_code, ~, inertia_tensor, ~] = obj.call_script_function(function_name, obj.DF_LUA_SCRIPT_API, obj_handle, [], obj.ABSOLUTE_FRAME, obj.ST_CHILD);
+                elseif(strcmp(reference_frame, obj.BODY_FRAME))
+                    [return_code, ~, inertia_tensor, ~] = obj.call_script_function(function_name, obj.DF_LUA_SCRIPT_API, [obj_handle, obj_handle], [], [], obj.ST_CHILD);
                 else
                     ref_frame_handle = obj.handle_from_string_or_handle(reference_frame);
                     [return_code, ~, inertia_tensor, ~] = obj.call_script_function(function_name, obj.DF_LUA_SCRIPT_API, [obj_handle, ref_frame_handle], [], [], obj.ST_CHILD);
                 end
             else % the call was: inertia_tensor =  get_inertia_matrix(objectname, reference_frame, function_name, obj_name)
-                if(reference_frame == obj.ABSOLUTE_FRAME)
+                if(strcmp(reference_frame, obj.ABSOLUTE_FRAME))
                     [return_code, ~, inertia_tensor, ~] = obj.call_script_function(function_name, obj_script_name, obj_handle, [], obj.ABSOLUTE_FRAME, obj.ST_CHILD);
+                elseif(strcmp(reference_frame, obj.BODY_FRAME))
+                    [return_code, ~, inertia_tensor, ~] = obj.call_script_function(function_name, obj_script_name, [obj_handle, obj_handle], [], [], obj.ST_CHILD);
                 else
                     ref_frame_handle = obj.handle_from_string_or_handle(reference_frame);
                     [return_code, ~, inertia_tensor, ~] = obj.call_script_function(function_name, obj_script_name, [obj_handle, ref_frame_handle], [], [], obj.ST_CHILD);

--- a/interfaces/vrep/DQ_VrepInterface.m
+++ b/interfaces/vrep/DQ_VrepInterface.m
@@ -803,8 +803,13 @@ classdef DQ_VrepInterface < handle
             end
 
             if(return_code ~= 0)
-                formatSpec = 'Script function `get_center_of_mass` returned with error code %i.\n';
-                fprintf(formatSpec, return_code);
+                if nargin <= 3
+                    formatSpec = 'Script function `get_center_of_mass` returned with error code %i.\n';
+                    fprintf(formatSpec, return_code);
+                else
+                    formatSpec = 'Script function %s returned with error code %i.\n';
+                    fprintf(formatSpec, function_name, return_code);
+                end
                 error('Failed calling script function!');
             else % ensure cast to double
                 center_of_mass = double(center_of_mass);
@@ -849,8 +854,13 @@ classdef DQ_VrepInterface < handle
             end
 
             if(return_code ~= 0)
-                formatSpec = 'Script function %s returned with error code %i.\n';
-                fprintf(formatSpec, function_name, return_code);
+                if nargin == 2
+                    formatSpec = 'Script function `get_mass` returned with error code %i.\n';
+                    fprintf(formatSpec, return_code);
+                else
+                    formatSpec = 'Script function %s returned with error code %i.\n';
+                    fprintf(formatSpec, function_name, return_code);
+                end
                 error('Failed calling script function!');
             else % ensure cast to double
                 mass = double(mass);
@@ -913,8 +923,13 @@ classdef DQ_VrepInterface < handle
             end
 
             if(return_code ~= 0)
-                formatSpec = 'Script function %s returned with error code %i.\n';
-                fprintf(formatSpec, function_name, return_code);
+                if nargin <= 3
+                    formatSpec = 'Script function `get_inertia` returned with error code %i.\n';
+                    fprintf(formatSpec, return_code);
+                else
+                    formatSpec = 'Script function %s returned with error code %i.\n';
+                    fprintf(formatSpec, function_name, return_code);
+                end
                 error('Failed calling script function!');
             else % ensure cast to double and reshape the 1x9 vector to a 3x3 matrix
                 inertia_tensor = double(reshape(inertia_tensor,3,3));

--- a/interfaces/vrep/DQ_VrepInterface.m
+++ b/interfaces/vrep/DQ_VrepInterface.m
@@ -101,8 +101,8 @@
 %
 %     3. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
 %       - Added the following methods:
-%             - call_script_function (see https://github.com/dqrobotics/matlab/pull/XXX)
-%             - get_center_of_mass (see https://github.com/dqrobotics/matlab/pull/XXX)
+%             - call_script_function() (see https://github.com/dqrobotics/matlab/pull/XXX)
+%             - get_center_of_mass() (see https://github.com/dqrobotics/matlab/pull/XXX)
 %             - get_mass() (see https://github.com/dqrobotics/matlab/pull/XXX)
 %             - get_inertia_matrix() (see https://github.com/dqrobotics/matlab/pull/XXX)
 %       - Added the following properties:
@@ -793,46 +793,27 @@ classdef DQ_VrepInterface < handle
 
             if nargin == 2 % the call was 'center_of_mass = get_center_of_mass(handle)'
                 [return_code,~,center_of_mass,~,~] = obj.call_script_function(obj.DF_LUA_SCRIPT_API, obj.ST_CHILD, 'get_center_of_mass', obj_handle, [], [], []);
-                if(return_code ~= 0)
-                    formatSpec = 'Script function `get_center_of_mass` returned with error code %i.\n';
-                    fprintf(formatSpec, return_code);
-                    error('Failed calling script function!');
-                else % ensure cast to double
-                    center_of_mass = double(center_of_mass);
-                end
             elseif nargin == 3 % the call was 'center_of_mass = get_center_of_mass(handle, reference_frame)'
                 ref_frame_handle = obj.handle_from_string_or_handle(ref_frame_handle_or_name);
 
                 [return_code,~,center_of_mass,~,~] = obj.call_script_function(obj.DF_LUA_SCRIPT_API, obj.ST_CHILD, 'get_center_of_mass', [obj_handle, ref_frame_handle], [], [], []);
-                if(return_code ~= 0)
-                    formatSpec = 'Script function `get_center_of_mass` returned with error code %i.\n';
-                    fprintf(formatSpec, return_code);
-                    error('Failed calling script function!');
-                else % ensure cast to double
-                    center_of_mass = double(center_of_mass);
-                end
             elseif nargin == 4 % the call was 'center_of_mass = get_center_of_mass(handle, reference_frame, function_name)'
                 ref_frame_handle = obj.handle_from_string_or_handle(ref_frame_handle_or_name);
 
                 [return_code,~,center_of_mass,~,~] = obj.call_script_function(obj.DF_LUA_SCRIPT_API, obj.ST_CHILD, function_name, [obj_handle, ref_frame_handle], [], [], []);
-                if(return_code ~= 0)
-                    formatSpec = 'Script function %s returned with error code %i.\n';
-                    fprintf(formatSpec, function_name, return_code);
-                    error('Failed calling script function!');
-                else % ensure cast to double
-                    center_of_mass = double(center_of_mass);
-                end
             else % the call was 'center_of_mass = get_center_of_mass(handle, reference_frame, function_name, obj_name)'
                 ref_frame_handle = obj.handle_from_string_or_handle(ref_frame_handle_or_name);
 
                 [return_code,~,center_of_mass,~,~] = obj.call_script_function(obj_script_name, obj.ST_CHILD, function_name, [obj_handle, ref_frame_handle], [], [], []);
-                if(return_code ~= 0)
-                    formatSpec = 'Script function %s returned with error code %i.\n';
-                    fprintf(formatSpec, function_name, return_code);
-                    error('Failed calling script function!');
-                else % ensure cast to double
-                    center_of_mass = double(center_of_mass);
-                end
+            end
+
+            if(return_code ~= 0)
+                formatSpec = 'Script function `get_center_of_mass` returned with error code %i.\n';
+                fprintf(formatSpec, return_code);
+                error('Failed calling script function!');
+            else % ensure cast to double
+                center_of_mass = double(center_of_mass);
+                center_of_mass = center_of_mass(1)*DQ.i + center_of_mass(2)*DQ.j + center_of_mass(3)*DQ.k;
             end
         end
 
@@ -868,31 +849,18 @@ classdef DQ_VrepInterface < handle
 
             if nargin == 2 % the call was 'mass = get_mass(handle)'
                 [return_code,~,mass,~,~] = obj.call_script_function(obj.DF_LUA_SCRIPT_API, obj.ST_CHILD, 'get_mass', obj_handle, [],[],[]);
-                if(return_code ~= 0)
-                    formatSpec = 'Script function `get_mass` returned with error code %i.\n';
-                    fprintf(formatSpec, return_code);
-                    error('Failed calling script function!');
-                else % ensure cast to double
-                    mass = double(mass);
-                end
             elseif nargin == 3 % the call was 'mass = get_mass(handle, function_name)'
                 [return_code,~,mass,~,~] = obj.call_script_function(obj.DF_LUA_SCRIPT_API, obj.ST_CHILD, function_name, obj_handle, [],[],[]);
-                if(return_code ~= 0)
-                    formatSpec = 'Script function %s returned with error code %i.\n';
-                    fprintf(formatSpec, function_name, return_code);
-                    error('Failed calling script function!');
-                else % ensure cast to double
-                    mass = double(mass);
-                end
             else % the call was 'mass = get_mass(handle, function_name, obj_name)'
                 [return_code,~,mass,~,~] = obj.call_script_function(obj_script_name, obj.ST_CHILD, function_name, obj_handle, [],[],[]);
-                if(return_code ~= 0)
-                    formatSpec = 'Script function %s returned with error code %i.\n';
-                    fprintf(formatSpec, function_name, return_code);
-                    error('Failed calling script function!');
-                else % ensure cast to double
-                    mass = double(mass);
-                end
+            end
+
+            if(return_code ~= 0)
+                formatSpec = 'Script function %s returned with error code %i.\n';
+                fprintf(formatSpec, function_name, return_code);
+                error('Failed calling script function!');
+            else % ensure cast to double
+                mass = double(mass);
             end
         end
 
@@ -932,46 +900,26 @@ classdef DQ_VrepInterface < handle
 
             if nargin == 2 % the call was 'inertia_tensor =  get_inertia_matrix(handle)'
                 [return_code,~,inertia_tensor,~,~] = obj.call_script_function(obj.DF_LUA_SCRIPT_API, obj.ST_CHILD, 'get_inertia', obj_handle, [], [], []);
-                if(return_code ~= 0)
-                    formatSpec = 'Script function `get_inertia` returned with error code %i.\n';
-                    fprintf(formatSpec, return_code);
-                    error('Failed calling script function!');
-                else % ensure cast to double and reshape the 1x9 vector to a 3x3 matrix
-                    inertia_tensor = double(reshape(inertia_tensor,3,3));
-                end
             elseif nargin == 3 % the call was 'inertia_tensor =  get_inertia_matrix(handle, reference_frame)'
                 ref_frame_handle = obj.handle_from_string_or_handle(ref_frame_handle_or_name);
 
                 [return_code,~,inertia_tensor,~,~] = obj.call_script_function(obj.DF_LUA_SCRIPT_API, obj.ST_CHILD, 'get_inertia', [obj_handle, ref_frame_handle], [], [], []);
-                if(return_code ~= 0)
-                    formatSpec = 'Script function `get_inertia` returned with error code %i.\n';
-                    fprintf(formatSpec, return_code);
-                    error('Failed calling script function!');
-                else % ensure cast to double and reshape the 1x9 vector to a 3x3 matrix
-                    inertia_tensor = double(reshape(inertia_tensor,3,3));
-                end
             elseif nargin == 4 % the call was 'inertia_tensor =  get_inertia_matrix(handle, reference_frame, function_name)'
                 ref_frame_handle = obj.handle_from_string_or_handle(ref_frame_handle_or_name);
 
                 [return_code,~,inertia_tensor,~,~] = obj.call_script_function(obj.DF_LUA_SCRIPT_API, obj.ST_CHILD, function_name, [obj_handle, ref_frame_handle], [], [], []);
-                if(return_code ~= 0)
-                    formatSpec = 'Script function %s returned with error code %i.\n';
-                    fprintf(formatSpec, function_name, return_code);
-                    error('Failed calling script function!');
-                else % ensure cast to double and reshape the 1x9 vector to a 3x3 matrix
-                    inertia_tensor = double(reshape(inertia_tensor,3,3));
-                end
             else % the call was 'inertia_tensor =  get_inertia_matrix(handle, reference_frame, function_name, obj_name)'
                 ref_frame_handle = obj.handle_from_string_or_handle(ref_frame_handle_or_name);
                 
                 [return_code,~,inertia_tensor,~,~] = obj.call_script_function(obj_script_name, obj.ST_CHILD, function_name, [obj_handle, ref_frame_handle], [], [], []);
-                if(return_code ~= 0)
-                    formatSpec = 'Script function %s returned with error code %i.\n';
-                    fprintf(formatSpec, function_name, return_code);
-                    error('Failed calling script function!');
-                else % ensure cast to double and reshape the 1x9 vector to a 3x3 matrix
-                    inertia_tensor = double(reshape(inertia_tensor,3,3));
-                end
+            end
+
+            if(return_code ~= 0)
+                formatSpec = 'Script function %s returned with error code %i.\n';
+                fprintf(formatSpec, function_name, return_code);
+                error('Failed calling script function!');
+            else % ensure cast to double and reshape the 1x9 vector to a 3x3 matrix
+                inertia_tensor = double(reshape(inertia_tensor,3,3));
             end
         end
         

--- a/interfaces/vrep/DQ_VrepInterface.m
+++ b/interfaces/vrep/DQ_VrepInterface.m
@@ -824,9 +824,9 @@ classdef DQ_VrepInterface < handle
             %
             %          objectname: The object's name.
             %          (optional) function_name: The name of the script function to call in the specified script.
-            %            (Default: "get_mass")
+            %             (Default: "get_mass")
             %          (optional) obj_script_name: The name of the object where the script is attached to.
-            %            (Default: 'DQRoboticsApiCommandServer')
+            %             (Default: 'DQRoboticsApiCommandServer')
             %
             %
             %     Check this link for more details: https://www.coppeliarobotics.com/helpFiles/en/regularApi/simGetShapeMass.htm
@@ -857,27 +857,23 @@ classdef DQ_VrepInterface < handle
             end
         end
 
-        function inertia_tensor =  get_inertia_matrix(obj, obj_handle_or_name, ref_frame_handle_or_name, function_name, obj_script_name)
+        function inertia_tensor =  get_inertia_matrix(obj, objectname, reference_frame, function_name, obj_script_name)
             % This method gets the inertia tensor of an object in the CoppeliaSim scene.
             %
             % Usage:
             %     Recommended:
-            %      inertia_tensor =  get_inertia_matrix(obj_handle_or_name);
+            %      inertia_tensor =  get_inertia_matrix(objectname);
             %
             %     Advanced:
-            %      inertia_tensor =  get_inertia_matrix(obj_handle_or_name, ref_frame_handle_or_name, function_name, obj_script_name);
+            %      inertia_tensor =  get_inertia_matrix(objectname, ref_frame_handle_or_name, function_name, obj_script_name);
             %
-            %          obj_handle_or_name: The object's handle or name.
-            %          (optional) reference_frame:  Indicates the handle of
-            %            the relative reference frame in which you want the
-            %            inertia tensor. If not specified, the shape's
-            %            reference frame is used.
-            %          (optional) function_name: The name of the script
-            %            function to call in the specified script.
-            %            (Default: "get_inertia")
-            %          (optional) obj_script_name: The name of the object
-            %            where the script is attached to. (Default:
-            %            'DQRoboticsApiCommandServer')
+            %          objectname: The object's handle or name.
+            %          (optional) reference_frame:  Indicates the handle of the relative reference frame in which you want the inertia tensor.
+            %             If not specified, the shape's reference frame is used.
+            %          (optional) function_name: The name of the script function to call in the specified script.
+            %             (Default: "get_inertia")
+            %          (optional) obj_script_name: The name of the object where the script is attached to.
+            %             (Default: 'DQRoboticsApiCommandServer')
             %
             %
             %     Check this link for more details: https://www.coppeliarobotics.com/helpFiles/en/regularApi/simGetShapeInertia.htm
@@ -887,24 +883,33 @@ classdef DQ_VrepInterface < handle
             %      inertia_tensor =  get_inertia_matrix('/Jaco/Jaco_link2');
             %
             %      % For advanced usage:
-            %      inertia_tensor = get_inertia_matrix('/Jaco/Jaco_link2', '/Jaco/Jaco_joint2', 'my_get_center_of_mass', 'my_DQRoboticsApiCommandServer');
+            %      inertia_tensor = get_inertia_matrix('/Jaco/Jaco_link2', '/Jaco/Jaco_joint2', 'my_get_inertia_matrix', 'my_DQRoboticsApiCommandServer');
 
-            obj_handle = obj.handle_from_string_or_handle(obj_handle_or_name);
+            obj_handle = obj.handle_from_string_or_handle(objectname);
 
-            if nargin == 2 % the call was 'inertia_tensor =  get_inertia_matrix(handle)'
-                [return_code,~,inertia_tensor,~,~] = obj.call_script_function(obj.DF_LUA_SCRIPT_API, obj.ST_CHILD, 'get_inertia', obj_handle, [], [], []);
-            elseif nargin == 3 % the call was 'inertia_tensor =  get_inertia_matrix(handle, reference_frame)'
-                ref_frame_handle = obj.handle_from_string_or_handle(ref_frame_handle_or_name);
-
-                [return_code,~,inertia_tensor,~,~] = obj.call_script_function(obj.DF_LUA_SCRIPT_API, obj.ST_CHILD, 'get_inertia', [obj_handle, ref_frame_handle], [], [], []);
-            elseif nargin == 4 % the call was 'inertia_tensor =  get_inertia_matrix(handle, reference_frame, function_name)'
-                ref_frame_handle = obj.handle_from_string_or_handle(ref_frame_handle_or_name);
-
-                [return_code,~,inertia_tensor,~,~] = obj.call_script_function(obj.DF_LUA_SCRIPT_API, obj.ST_CHILD, function_name, [obj_handle, ref_frame_handle], [], [], []);
-            else % the call was 'inertia_tensor =  get_inertia_matrix(handle, reference_frame, function_name, obj_name)'
-                ref_frame_handle = obj.handle_from_string_or_handle(ref_frame_handle_or_name);
-                
-                [return_code,~,inertia_tensor,~,~] = obj.call_script_function(obj_script_name, obj.ST_CHILD, function_name, [obj_handle, ref_frame_handle], [], [], []);
+            if nargin == 2 % the call was: inertia_tensor =  get_inertia_matrix(objectname)
+                [return_code, ~, inertia_tensor, ~] = obj.call_script_function('get_inertia', obj.DF_LUA_SCRIPT_API, obj_handle, [], [], obj.ST_CHILD);
+            elseif nargin == 3 % the call was: inertia_tensor =  get_inertia_matrix(objectname, reference_frame)
+                if(reference_frame == obj.ABSOLUTE_FRAME)
+                    [return_code, ~, inertia_tensor, ~] = obj.call_script_function('get_inertia', obj.DF_LUA_SCRIPT_API, obj_handle, [], obj.ABSOLUTE_FRAME, obj.ST_CHILD);
+                else
+                    ref_frame_handle = obj.handle_from_string_or_handle(reference_frame);
+                    [return_code, ~, inertia_tensor, ~] = obj.call_script_function('get_inertia', obj.DF_LUA_SCRIPT_API, [obj_handle, ref_frame_handle], [], [], obj.ST_CHILD);
+                end
+            elseif nargin == 4 % the call was: inertia_tensor =  get_inertia_matrix(objectname, reference_frame, function_name)
+                if(reference_frame == obj.ABSOLUTE_FRAME)
+                    [return_code, ~, inertia_tensor, ~] = obj.call_script_function(function_name, obj.DF_LUA_SCRIPT_API, obj_handle, [], obj.ABSOLUTE_FRAME, obj.ST_CHILD);
+                else
+                    ref_frame_handle = obj.handle_from_string_or_handle(reference_frame);
+                    [return_code, ~, inertia_tensor, ~] = obj.call_script_function(function_name, obj.DF_LUA_SCRIPT_API, [obj_handle, ref_frame_handle], [], [], obj.ST_CHILD);
+                end
+            else % the call was: inertia_tensor =  get_inertia_matrix(objectname, reference_frame, function_name, obj_name)
+                if(reference_frame == obj.ABSOLUTE_FRAME)
+                    [return_code, ~, inertia_tensor, ~] = obj.call_script_function(function_name, obj_script_name, obj_handle, [], obj.ABSOLUTE_FRAME, obj.ST_CHILD);
+                else
+                    ref_frame_handle = obj.handle_from_string_or_handle(reference_frame);
+                    [return_code, ~, inertia_tensor, ~] = obj.call_script_function(function_name, obj_script_name, [obj_handle, ref_frame_handle], [], [], obj.ST_CHILD);
+                end
             end
 
             if(return_code ~= 0)

--- a/interfaces/vrep/DQ_VrepInterface.m
+++ b/interfaces/vrep/DQ_VrepInterface.m
@@ -815,23 +815,21 @@ classdef DQ_VrepInterface < handle
             end
         end
 
-        function mass = get_mass(obj, obj_handle_or_name, function_name, obj_script_name)
+        function mass = get_mass(obj, objectname, function_name, obj_script_name)
             % This method gets the mass of an object in the CoppeliaSim scene.
             %
             % Usage:
             %     Recommended:
-            %      mass = get_mass(obj_handle_or_name);
+            %      mass = get_mass(objectname);
             %
             %     Advanced:
-            %      mass = get_mass(obj_handle_or_name, function_name, obj_script_name);
+            %      mass = get_mass(objectname, function_name, obj_script_name);
             %
-            %          obj_handle_or_name: The object's handle or name.
-            %          (optional) function_name: The name of the script
-            %            function to call in the specified script.
+            %          objectname: The object's name.
+            %          (optional) function_name: The name of the script function to call in the specified script.
             %            (Default: "get_mass")
-            %          (optional) obj_script_name: The name of the object
-            %            where the script is attached to. (Default:
-            %            'DQRoboticsApiCommandServer')
+            %          (optional) obj_script_name: The name of the object where the script is attached to.
+            %            (Default: 'DQRoboticsApiCommandServer')
             %
             %
             %     Check this link for more details: https://www.coppeliarobotics.com/helpFiles/en/regularApi/simGetShapeMass.htm
@@ -843,14 +841,14 @@ classdef DQ_VrepInterface < handle
             %      % For advanced usage:
             %      mass = get_mass('/Jaco/Jaco_link2', 'my_get_center_of_mass', 'my_DQRoboticsApiCommandServer');
 
-            obj_handle = obj.handle_from_string_or_handle(obj_handle_or_name);
+            obj_handle = obj.handle_from_string_or_handle(objectname);
 
-            if nargin == 2 % the call was 'mass = get_mass(handle)'
-                [return_code,~,mass,~,~] = obj.call_script_function(obj.DF_LUA_SCRIPT_API, obj.ST_CHILD, 'get_mass', obj_handle, [],[],[]);
-            elseif nargin == 3 % the call was 'mass = get_mass(handle, function_name)'
-                [return_code,~,mass,~,~] = obj.call_script_function(obj.DF_LUA_SCRIPT_API, obj.ST_CHILD, function_name, obj_handle, [],[],[]);
-            else % the call was 'mass = get_mass(handle, function_name, obj_name)'
-                [return_code,~,mass,~,~] = obj.call_script_function(obj_script_name, obj.ST_CHILD, function_name, obj_handle, [],[],[]);
+            if nargin == 2 % the call was: mass = get_mass(objectname)
+                [return_code, ~, mass, ~] = obj.call_script_function('get_mass', obj.DF_LUA_SCRIPT_API, obj_handle, [], [], obj.ST_CHILD);
+            elseif nargin == 3 % the call was: mass = get_mass(objectname, function_name)
+                [return_code, ~, mass, ~] = obj.call_script_function(function_name, obj.DF_LUA_SCRIPT_API, obj_handle, [], [], obj.ST_CHILD);
+            else % the call was: mass = get_mass(objectname, function_name, obj_name)
+                [return_code, ~, mass, ~] = obj.call_script_function(function_name, obj_script_name, obj_handle, [], [], obj.ST_CHILD);
             end
 
             if(return_code ~= 0)


### PR DESCRIPTION
# Main instructions

By submitting this pull request, you automatically agree that you have read and accepted the following conditions:

- Anyone wanting to propose a new modification or introduce new functionality should reach out to the team first, as proposed modifications that do not comply with the library's development philosophy and style, do not follow the library's architecture, do not introduce a clear and general benefit to the library other than to the person who proposed the modification will likely be rejected with no further discussion.
- Support for DQ Robotics is given voluntarily and it is not the developers' role to educate and/or convince anyone of their vision.
- Any possible response and its timeliness will be based on the relevance, accuracy, and politeness of a request and the following discussion.
- You are familiar with the [development workflow](https://github.com/dqrobotics/matlab/blob/master/CONTRIBUTING.md).
- Each pull request should contain only individual changes (several changes of the same type **are allowed** on the same pull request).
- Refactoring or modifying internal implementation that is working is not allowed unless comprehensively discussed with and approved by @bvadorno and @mmmarinho.


## Description of changes

Hi, @dqrobotics/developers,

I've added to the class `DQ_VrepInterface`:
- The properties:
   - `DF_LUA_SCRIPT_API`
   - `ST_CHILD`
- The methods:
   - `call_script_function()`
   - `get_center_of_mass()`
   - `get_mass()`
   - `get_inertia_matrix()`

It **diverges** from the implementation of its [C++ counterpart](https://github.com/dqrobotics/cpp-interface-vrep/blob/master/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp) in the following regards:
- `DF_LUA_SCRIPT_API` stores the default name (`/DQRoboticsApiCommandServer`) for the child script in CoppeliaSim with the LUA methods necessary to read an object's inertia parameters;
- Method `call_script_function()` follows the signature of the underlying CoppeliaSim API method `simxCallScriptFunction`;
- Methods `get_center_of_mass()` and `get_inertia_matrix()` pass the relative reference frame parameter as an int to method `call_script_function()`.

An example of use is given in [10](https://github.com/dqrobotics/matlab-examples/pull/10).

## Rationale

The class `DQ_VrepInterface` already has the methods `call_script_function()`, `get_center_of_mass()`, `get_mass()`, and `get_inertia_matrix()` in the C++ library but they were missing on MATLAB.

The reasons for the **divergence** with the C++ implementation are:
- It's cleaner and more transparent to have de default LUA child script name defined as a constant property of the class rather than a constant input for the methods;
- The C++ implementation of `call_script_function()` scrambles the input arguments of the underlying CoppeliaSim API method `simxCallScriptFunction` (e.g., `function_name` goes from being the third argument to being the first). This is unnecessarily confusing and adds no real benefit to its usage.
- As the methods `get_center_of_mass()` and `get_inertia_matrix()` are in their C++ implementation, they do not allow for arbitrary reference frames. More details on that are given in [10](https://github.com/dqrobotics/matlab-examples/pull/10), where I discuss the modifications I've made to the default LUA script used for getting the inertial parameters of an object.

Kind regards,
Frederico