### PR TITLE
This PR fixes issue #74: language incompatibility in DQ_KinematicController not resetting the stable region flag

### DIFF
--- a/robot_control/DQ_KinematicController.m
+++ b/robot_control/DQ_KinematicController.m
@@ -60,9 +60,9 @@
 % DQ Robotics website: dqrobotics.github.io
 %
 % Contributors to this file:
-%     1. Bruno Vihena Adorno - adorno@ufmg.br
+%     1. Bruno Vihena Adorno - adorno@ieee.org
 %        - Responsible for the original implementation
-%     2. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+%     2. Frederico Fernandes Afonso Silva - frederico.silva@ieee.org
 %        - Modified the 'reset_stability_counter()' method to ensure
 %        compatibility with its C++ version:
 %             - The flag 'system_reached_stable_region_' is now reset to

--- a/robot_control/DQ_KinematicController.m
+++ b/robot_control/DQ_KinematicController.m
@@ -136,6 +136,7 @@ classdef DQ_KinematicController < handle
         function reset_stability_counter(obj)
         % Reset the stability counter to zero
             obj.stability_counter = 0;
+            obj.system_reached_stable_region_ = false;
         end
         
         function set_stability_counter_max(obj, max)

--- a/robot_control/DQ_KinematicController.m
+++ b/robot_control/DQ_KinematicController.m
@@ -39,7 +39,7 @@
 %   DQ_TaskspaceQuadraticProgrammingController.
 
 
-% (C) Copyright 2011-2019 DQ Robotics Developers
+% (C) Copyright 2011-2024 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %
@@ -60,7 +60,14 @@
 % DQ Robotics website: dqrobotics.github.io
 %
 % Contributors to this file:
-%     Bruno Vihena Adorno - adorno@ufmg.br
+%     1. Bruno Vihena Adorno - adorno@ufmg.br
+%        - Responsible for the original implementation
+%     2. Frederico Fernandes Afonso Silva (frederico.silva@ieee.org)
+%        - Modified the 'reset_stability_counter()' method to ensure
+%        compatibility with its C++ version:
+%             - The flag 'system_reached_stable_region_' is now reset to
+%             'false'.
+
 classdef DQ_KinematicController < handle
     properties (Access=protected)
         % Controlled primitive attached to the end-effector. It is

--- a/robot_control/DQ_KinematicController.m
+++ b/robot_control/DQ_KinematicController.m
@@ -134,7 +134,8 @@ classdef DQ_KinematicController < handle
         end
         
         function reset_stability_counter(obj)
-        % Reset the stability counter to zero
+        % Reset the stability counter to zero and the flag indicating that
+        % the system has reached a stable region to false.
             obj.stability_counter = 0;
             obj.system_reached_stable_region_ = false;
         end


### PR DESCRIPTION
# Main instructions

By submitting this pull request, you automatically agree that you have read and accepted the following conditions:

- Anyone wanting to propose a new modification or introduce new functionality should reach out to the team first, as proposed modifications that do not comply with the library's development philosophy and style, do not follow the library's architecture, do not introduce a clear and general benefit to the library other than to the person who proposed the modification will likely be rejected with no further discussion.
- Support for DQ Robotics is given voluntarily and it is not the developers' role to educate and/or convince anyone of their vision.
- Any possible response and its timeliness will be based on the relevance, accuracy, and politeness of a request and the following discussion.
- You are familiar with the [development workflow](https://github.com/dqrobotics/matlab/blob/master/CONTRIBUTING.md).
- Each pull request should contain only individual changes (several changes of the same type **are allowed** on the same pull request).
- Refactoring or modifying internal implementation that is working is not allowed unless comprehensively discussed with and approved by @bvadorno and @mmmarinho.


## Description of changes

I have modified the `reset_stability_counter()` method to ensure compatibility with its [C++ version](https://github.com/dqrobotics/cpp/blob/master/src/robot_control/DQ_KinematicController.cpp). Namely, the flag `system_reached_stable_region_` is now reset to `false`.

## Rationale

This pull request fixes issue #74.