### PR TITLE
This PR adds the pose jacobian derivative in the DQ_Kinematic class

### DIFF
--- a/robot_modeling/DQ_DifferentialDriveRobot.m
+++ b/robot_modeling/DQ_DifferentialDriveRobot.m
@@ -14,7 +14,7 @@
 % See also DQ_HolonomicBase.
 
 
-% (C) Copyright 2011-2019 DQ Robotics Developers
+% (C) Copyright 2011-2025 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %
@@ -34,7 +34,11 @@
 % DQ Robotics website: dqrobotics.github.io
 %
 % Contributors to this file:
-%     Bruno Vihena Adorno - adorno@ufmg.br
+%    1.  Bruno Vihena Adorno - adorno@ufmg.br
+%
+%    2. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
+%        - Added the method pose_jacobian_derivative(). 
+%          However, the method is not implemented yet.
 
 classdef DQ_DifferentialDriveRobot < DQ_HolonomicBase
     
@@ -77,6 +81,18 @@ classdef DQ_DifferentialDriveRobot < DQ_HolonomicBase
             % q = [x,y,phi] is the robot configuration
             J_holonomic = pose_jacobian@DQ_HolonomicBase(obj,q);
             J = J_holonomic*obj.constraint_jacobian(q(3));
+        end
+
+        function J_dot = pose_jacobian_derivative(obj, q, q_dot)
+        % J_dot = pose_jacobian_derivative(q, q_dot) returns the time
+        % derivative of the Jacobian matrix that satisfies 
+        % vec8(h_dot_dot) = J_dot*[wr,wl]' + J*[wr_dot,wl_dot]', where h_dot is the time
+        % derivative of the unit dual quaternion that represent the
+        % mobile base pose and  wr and wl are the angular velocities of the
+        % right and left wheels, respectively. 
+        % q = [x,y,phi] is the robot configuration
+
+            error('pose_jacobian_derivative is not implemented yet');
         end
     end
 end

--- a/robot_modeling/DQ_DifferentialDriveRobot.m
+++ b/robot_modeling/DQ_DifferentialDriveRobot.m
@@ -34,7 +34,7 @@
 % DQ Robotics website: dqrobotics.github.io
 %
 % Contributors to this file:
-%    1.  Bruno Vihena Adorno - adorno@ufmg.br
+%    1.  Bruno Vihena Adorno - adorno@ieee.org
 %
 %    2. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
 %        - Added the method pose_jacobian_derivative(). 

--- a/robot_modeling/DQ_HolonomicBase.m
+++ b/robot_modeling/DQ_HolonomicBase.m
@@ -16,7 +16,7 @@
 %
 %       See also DQ_MobileBase, DQ_DifferentialDriveRobot
 
-% (C) Copyright 2011-2019 DQ Robotics Developers
+% (C) Copyright 2011-2025 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %
@@ -36,7 +36,11 @@
 % DQ Robotics website: dqrobotics.github.io
 %
 % Contributors to this file:
-%     Bruno Vihena Adorno - adorno@ufmg.br
+%    1.  Bruno Vihena Adorno - adorno@ufmg.br
+%
+%    2. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
+%        - Added the method pose_jacobian_derivative(). 
+%          However, the method is not implemented yet.
 
 classdef DQ_HolonomicBase < DQ_MobileBase
     
@@ -136,6 +140,16 @@ classdef DQ_HolonomicBase < DQ_MobileBase
                 % DQ_Kinematics objects.
                  J = haminus8(obj.frame_displacement)*obj.raw_pose_jacobian(q);
             end
+        end
+
+        function J_dot = pose_jacobian_derivative(obj, q, q_dot, ~)
+        % POSE_JACOBIAN_DERIVATIVE(q, q_dot) returns, given the configuration
+        % q = [x,y,phi]', the mobile-base pose Jacobian derivative J_dot that satisfies 
+        % x_dot_dot = J_dot*q_dot + J*q_dot_dot, where x_dot is the time derivative 
+        % of the unit dual quaternion that represents the mobile-base pose. It takes into
+        % consideration the base frame displacement (e.g., base height). 
+
+            error('pose_jacobian_derivative is not implemented yet');
         end
         
         function set_base_diameter(obj,diameter)

--- a/robot_modeling/DQ_HolonomicBase.m
+++ b/robot_modeling/DQ_HolonomicBase.m
@@ -36,7 +36,7 @@
 % DQ Robotics website: dqrobotics.github.io
 %
 % Contributors to this file:
-%    1.  Bruno Vihena Adorno - adorno@ufmg.br
+%    1.  Bruno Vihena Adorno - adorno@ieee.org
 %
 %    2. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
 %        - Added the method pose_jacobian_derivative(). 

--- a/robot_modeling/DQ_Kinematics.m
+++ b/robot_modeling/DQ_Kinematics.m
@@ -37,7 +37,7 @@
 %       translation_jacobian - Compute the translation Jacobian.
 % See also DQ_SerialManipulator, DQ_MobileBase, DQ_CooperativeDualTaskSpace.
 
-% (C) Copyright 2011-2023 DQ Robotics Developers
+% (C) Copyright 2011-2025 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %
@@ -60,10 +60,11 @@
 %     1. Bruno Vihena Adorno (adorno@ieee.org)
 %          Responsible for the original implementation. 
 %
-%     2. Juan Jose Quiroz Omana (juanjqo@g.ecc.u-tokyo.ac.jp)
+%     2. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
 %        - Added the property dim_configuration_space. 
 %        - Added the method line_to_line_angle_residual().
 %        - Added the methods check_ith_link() and check_q_vec().
+%        - Added the method pose_jacobian_derivative().
 
 classdef DQ_Kinematics < handle
     % DQ_Kinematics inherits the HANDLE superclass to avoid unnecessary copies

--- a/robot_modeling/DQ_Kinematics.m
+++ b/robot_modeling/DQ_Kinematics.m
@@ -173,6 +173,13 @@ classdef DQ_Kinematics < handle
         % POSE_JACOBIAN(q, to_ith_link) calculates the forward kinematic model up to
         % the ith element in the chain.
         J = pose_jacobian(obj, q, to_ith_link);
+
+        % POSE_JACOBIAN_DERIVATIVE(q, q_dot) returns the Jacobian derivative 'J_dot' that satisfies
+        % vec8(x_pose_dot_dot) = J_dot * q_dot + J*q_dot_dot, where x_pose = fkm(q), 'x_pose_dot_dot' is 
+        % the second time derivative of the 'x_pose' and 'q_dot' represents the robot configuration velocities.
+        % J_dot = pose_jacobian_derivative(obj, q, q_dot, to_ith_link) calculates the jacobian derivative up 
+        % to the ith element in the chain.
+        J_dot = pose_jacobian_derivative(obj, q, q_dot, to_ith_link);
     end
     
     methods(Static)

--- a/robot_modeling/DQ_SerialWholeBody.m
+++ b/robot_modeling/DQ_SerialWholeBody.m
@@ -51,7 +51,7 @@
 %
 % See also DQ_kinematics, DQ_MobileBase
 
-% (C) Copyright 2011-2023 DQ Robotics Developers
+% (C) Copyright 2011-2025 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %
@@ -71,7 +71,10 @@
 % DQ Robotics website: dqrobotics.github.io
 %
 % Contributors to this file:
-%     Bruno Vihena Adorno - adorno@ieee.org
+%    1. Bruno Vihena Adorno - adorno@ieee.org
+%
+%    2. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
+%        - Added the method pose_jacobian_derivative(). However, the method is not implemented yet.
 
 classdef DQ_SerialWholeBody < DQ_Kinematics
     properties (Access = protected)
@@ -590,6 +593,18 @@ classdef DQ_SerialWholeBody < DQ_Kinematics
                 error(['set_effector() is available only if the last element'...
                     ' in the kinematic chain is a DQ_SerialManipulator object']);
             end
+        end
+
+        function J_dot = pose_jacobian_derivative(obj, q, q_dot, ith)
+            % Returns the whole-body pose Jacobian.
+            % J_dot = POSE_JACOBIAN_DERIVATIVE(q, q_dot) receives the configuration vector q and configuration 
+            % velocity vector q_dot of the whole kinematic chain and returns the jacobian derivative J_dot that satisfies
+            % vec8(xdot_dot) = J_dot*q_dot + J*q_dot_dot, where q_dot is the configuration velocity
+            % and xdot is the time derivative of the unit dual quaternion that represents the end-effector pose.
+            % J = POSE_JACOBIAN_DERIVATIVE(q, q_dot, ith) calculates the Jacobian derivative up to the ith
+            % link of the combined kinematic chain.
+
+            error('pose_jacobian_derivative is not implemented yet');
         end
     end
 end

--- a/robot_modeling/DQ_WholeBody.m
+++ b/robot_modeling/DQ_WholeBody.m
@@ -62,7 +62,7 @@
 % DQ Robotics website: dqrobotics.github.io
 %
 % Contributors to this file:
-%    1.  Bruno Vihena Adorno - adorno@ufmg.br
+%    1.  Bruno Vihena Adorno - adorno@ieee.org
 %
 %    2. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
 %        - Added the method pose_jacobian_derivative(). 

--- a/robot_modeling/DQ_WholeBody.m
+++ b/robot_modeling/DQ_WholeBody.m
@@ -42,7 +42,7 @@
 %
 % See also DQ_kinematics, DQ_MobileBase
 
-% (C) Copyright 2011-2023 DQ Robotics Developers
+% (C) Copyright 2011-2025 DQ Robotics Developers
 %
 % This file is part of DQ Robotics.
 %
@@ -62,7 +62,11 @@
 % DQ Robotics website: dqrobotics.github.io
 %
 % Contributors to this file:
-%     Bruno Vihena Adorno -  adorno@ieee.org
+%    1.  Bruno Vihena Adorno - adorno@ufmg.br
+%
+%    2. Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
+%        - Added the method pose_jacobian_derivative(). 
+%          However, the method is not implemented yet.
 
 classdef DQ_WholeBody < DQ_Kinematics
     properties (Access = protected)
@@ -477,6 +481,19 @@ classdef DQ_WholeBody < DQ_Kinematics
                 error(['set_effector() is available only if the last element'...
                     ' in the kinematic chain is a DQ_SerialManipulator object']);
             end
+        end
+
+
+        function J_dot = pose_jacobian_derivative(obj, q, q_dot, ith)
+            % Returns the whole-body pose Jacobian.
+            % J_dot = POSE_JACOBIAN_DERIVATIVE(q, q_dot) receives the configuration vector q and configuration 
+            % velocity vector q_dot of the whole kinematic chain and returns the jacobian derivative J_dot that satisfies
+            % vec8(xdot_dot) = J_dot*q_dot + J*q_dot_dot, where q_dot is the configuration velocity
+            % and xdot is the time derivative of the unit dual quaternion that represents the end-effector pose.
+            % J = POSE_JACOBIAN_DERIVATIVE(q, q_dot, ith) calculates the Jacobian derivative up to the ith
+            % link of the combined kinematic chain.
+
+            error('pose_jacobian_derivative is not implemented yet');
         end
     end
 end


### PR DESCRIPTION
# Main instructions

By submitting this pull request, you automatically agree that you have read and accepted the following conditions:

- Anyone wanting to propose a new modification or introduce new functionality should reach out to the team first, as proposed modifications that do not comply with the library's development philosophy and style, do not follow the library's architecture, do not introduce a clear and general benefit to the library other than to the person who proposed the modification will likely be rejected with no further discussion.
- Support for DQ Robotics is given voluntarily and it is not the developers' role to educate and/or convince anyone of their vision.
- Any possible response and its timeliness will be based on the relevance, accuracy, and politeness of a request and the following discussion.
- You are familiar with the [development workflow](https://github.com/dqrobotics/matlab/blob/master/CONTRIBUTING.md).
- Each pull request should contain only individual changes (several changes of the same type **are allowed** on the same pull request).
- Refactoring or modifying internal implementation that is working is not allowed unless comprehensively discussed with and approved by @bvadorno and @mmmarinho.


## Description of changes

This PR adds the abstract method `pose_jacobian_derivative()` in the `DQ_Kinematics` class. The subclasses implement the respective concrete methods, but an exception is thrown if the user tries to use them. In other words, the concrete methods are not yet available to the user (except for the DQ_SerialManipulator class, in which the `pose_jacobian_derivative` method is implemented since 4ada8bbdfba8b43ae2cb4e4a4352f5385899e480). The concrete implementations for each subclass will be proposed in future PRs.

Current:

![JacobianDerivative_pre](https://github.com/user-attachments/assets/8d791aee-b8ee-45fb-a9b8-6d9166c1f116)

Proposal:
![JacobianDerivative](https://github.com/user-attachments/assets/7b8f5e2b-b923-410e-94f2-130751cdb8be)


## Rationale

- This is one of the pending tasks defined in [developers-playground](https://github.com/dqrobotics/developers-playground/discussions/1). 
- This modification was implemented in the C++ version in dqrobotics/cpp#48

- The `pose_jacobian_derivative()` method is a requirement for the future _Gauss Principle of Least Constraint_ solver.


Kind regards, 

Juancho
