### PR TITLE
This PR adds the get link transformation method in the serial manipulator classes 

### DIFF
--- a/robot_modeling/DQ_SerialManipulator.m
+++ b/robot_modeling/DQ_SerialManipulator.m
@@ -86,6 +86,11 @@ classdef (Abstract) DQ_SerialManipulator < DQ_Kinematics
         st = get_supported_joint_types();
      end
 
+     methods (Abstract)
+         % This method returns the corresponding dual quaternion for a given link's parameters.
+         get_link_transformation(q, ith);
+     end
+
      methods (Access = protected)  
          function check_joint_types(obj)
             %  CHECK_JOINT_TYPES() throws an exception if the joint types

--- a/robot_modeling/DQ_SerialManipulatorDH.m
+++ b/robot_modeling/DQ_SerialManipulatorDH.m
@@ -203,6 +203,22 @@ classdef DQ_SerialManipulatorDH < DQ_SerialManipulator
             obj.set_joint_types(A(5,:));
         end
 
+        function x = get_link_transformation(obj, q, ith)
+            %   This method exposes the protected method get_link2dq(),
+            %   which calculates  the corresponding dual quaternion for a
+            %   given link's DH parameters.
+            % Usage:
+            %     get_link_transformation(q, ith)
+            %          q: The joint value.
+            %          ith: The link number.
+            %
+            % Example: 
+            %      robot = KukaLwr4Robot.kinematics();
+            %      x = robot.get_link_transformation(pi/2, 3);
+
+            x = get_link2dq(obj, q, ith);
+        end
+
         function ret = get_parameters(obj, parameterType)
             % This method returns a vector containing the DH parameters.
             % Usage: get_parameters(parameterType)

--- a/robot_modeling/DQ_SerialManipulatorMDH.m
+++ b/robot_modeling/DQ_SerialManipulatorMDH.m
@@ -201,7 +201,7 @@ classdef DQ_SerialManipulatorMDH < DQ_SerialManipulator
         function x = get_link_transformation(obj, q, ith)
             %   This method exposes the protected method get_link2dq(),
             %   which calculates  the corresponding dual quaternion for a
-            %   given link's DH parameters.
+            %   given link's MDH parameters.
             % Usage:
             %     get_link_transformation(q, ith)
             %          q: The joint value.

--- a/robot_modeling/DQ_SerialManipulatorMDH.m
+++ b/robot_modeling/DQ_SerialManipulatorMDH.m
@@ -198,6 +198,22 @@ classdef DQ_SerialManipulatorMDH < DQ_SerialManipulator
             obj.set_joint_types(A(5,:));
         end
 
+        function x = get_link_transformation(obj, q, ith)
+            %   This method exposes the protected method get_link2dq(),
+            %   which calculates  the corresponding dual quaternion for a
+            %   given link's DH parameters.
+            % Usage:
+            %     get_link_transformation(q, ith)
+            %          q: The joint value.
+            %          ith: The link number.
+            %
+            % Example: 
+            %      robot = ComauSmartSixRobot.kinematics();
+            %      x = robot.get_link_transformation(pi/2, 3);
+
+            x = get_link2dq(obj, q, ith);
+        end
+
         function ret = get_parameters(obj, parameterType)
             % This method returns a vector containing the DH parameters.
             % Usage: get_parameters(parameterType)


### PR DESCRIPTION
# Main instructions

By submitting this pull request, you automatically agree that you have read and accepted the following conditions:

- Anyone wanting to propose a new modification or introduce new functionality should reach out to the team first, as proposed modifications that do not comply with the library's development philosophy and style, do not follow the library's architecture, do not introduce a clear and general benefit to the library other than to the person who proposed the modification will likely be rejected with no further discussion.
- Support for DQ Robotics is given voluntarily and it is not the developers' role to educate and/or convince anyone of their vision.
- Any possible response and its timeliness will be based on the relevance, accuracy, and politeness of a request and the following discussion.
- You are familiar with the [development workflow](https://github.com/dqrobotics/matlab/blob/master/CONTRIBUTING.md).
- Each pull request should contain only individual changes (several changes of the same type **are allowed** on the same pull request).
- Refactoring or modifying internal implementation that is working is not allowed unless comprehensively discussed with and approved by @bvadorno and @mmmarinho.


## Description of changes
 
This PR adds the abstract method `get_link_transformation()` to the `DQ_SerialManipulator` class and provides concrete implementations of it in the `DQ_SerialManipulatorDH` and `DQ_SerialManipulatorMDH` classes.

This method exposes the `get_link2dq()` methods of the concrete classes, which calculate the corresponding dual quaternion for a given link's parameters.

## Rationale

This is one of the methods proposed in the [discussions regarding the DQ_Dynamic class](https://github.com/dqrobotics/developers-playground/discussions/17), and is required to simplify how the `DQ_DynamicsSolver` calculates relative displacements between links.